### PR TITLE
Server HTTP route testing

### DIFF
--- a/common/src/api/device.rs
+++ b/common/src/api/device.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::address::{AccountId, DeviceId, RegistrationId};
 
-use super::keys::PublishPreKeys;
+use super::keys::RegistrationPreKeys;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -43,5 +43,5 @@ pub struct LinkDeviceRequest {
 pub struct DeviceActivationInfo {
     pub name: String,
     pub registration_id: RegistrationId,
-    pub key_bundle: PublishPreKeys,
+    pub key_bundle: RegistrationPreKeys,
 }

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -8,4 +8,5 @@ pub enum LibError {
     Custom(String),
     #[error(ignore)]
     AuthorizationError(String),
+    RegistrationKeyFieldsRequired,
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -29,3 +29,5 @@ rustls = { version = "0.23.15", features = ["ring"] }
 axum-test = "17.2.0"
 tokio-tungstenite = "0.26.2"
 maplit = "1.0.2"
+serde_json = "1.0.139"
+rstest = "0.24.0"

--- a/server/src/auth/device.rs
+++ b/server/src/auth/device.rs
@@ -18,7 +18,11 @@ pub fn create_token(secret: &str, account_id: AccountId) -> LinkDeviceToken {
     LinkDeviceToken::new(id, token)
 }
 
-pub fn verify_token(secret: &str, token: LinkDeviceToken) -> Result<AccountId, ServerError> {
+pub fn verify_token(
+    secret: &str,
+    expire_seconds: u64,
+    token: LinkDeviceToken,
+) -> Result<AccountId, ServerError> {
     let (claims, b64_signature) = token
         .token()
         .split_once(":")
@@ -44,7 +48,7 @@ pub fn verify_token(secret: &str, token: LinkDeviceToken) -> Result<AccountId, S
     );
     let time_now = Duration::from_millis(time_now_millis() as u64);
     let elapsed = time_now - time_then;
-    if elapsed.as_secs() > 600 {
+    if elapsed.as_secs() > expire_seconds {
         return Err(ServerError::DeviceLinkTooSlow);
     }
     Ok(account_id)

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -16,6 +16,7 @@ pub enum ServerError {
     DeviceWrongSignature,
     DeviceLinkTooSlow,
     DeviceProvisionUnAuth,
+    DeviceUnAuth,
     AccountIDUnParsable,
     PasswordHashError,
     WrongPassword,
@@ -48,7 +49,7 @@ impl IntoResponse for ServerError {
             ServerError::DeviceTokenMalformed => StatusCode::INTERNAL_SERVER_ERROR,
             ServerError::DeviceSignatureDecodeError => StatusCode::INTERNAL_SERVER_ERROR,
             ServerError::DeviceWrongSignature => StatusCode::INTERNAL_SERVER_ERROR,
-            ServerError::DeviceLinkTooSlow => StatusCode::INTERNAL_SERVER_ERROR,
+            ServerError::DeviceLinkTooSlow => StatusCode::FORBIDDEN,
             ServerError::DeviceProvisionUnAuth => StatusCode::INTERNAL_SERVER_ERROR,
             ServerError::AccountIDUnParsable => StatusCode::INTERNAL_SERVER_ERROR,
             ServerError::PasswordHashError => StatusCode::INTERNAL_SERVER_ERROR,
@@ -70,6 +71,7 @@ impl IntoResponse for ServerError {
             ServerError::MessageNotPending => StatusCode::INTERNAL_SERVER_ERROR,
             ServerError::EnvelopeMalformed => StatusCode::INTERNAL_SERVER_ERROR,
             ServerError::MessageSubscriberSendErorr => StatusCode::INTERNAL_SERVER_ERROR,
+            ServerError::DeviceUnAuth => StatusCode::UNAUTHORIZED,
         }
         .into_response()
     }

--- a/server/src/logic/keys.rs
+++ b/server/src/logic/keys.rs
@@ -162,7 +162,7 @@ mod test {
             },
         },
         state::ServerState,
-        test_utils::create_publish_key_bundle,
+        test_utils::create_publish_pre_keys,
     };
 
     #[tokio::test]
@@ -173,7 +173,7 @@ mod test {
 
         let account_id = AccountId::generate();
 
-        let key_bundle = create_publish_key_bundle(
+        let key_bundle = create_publish_pre_keys(
             Some(vec![1, 2]),
             Some(1),
             Some(vec![1, 2]),
@@ -221,7 +221,7 @@ mod test {
 
         let account_id = AccountId::generate();
 
-        let key_bundle = create_publish_key_bundle(
+        let key_bundle = create_publish_pre_keys(
             Some(vec![1, 2]),
             Some(22),
             Some(vec![1]),
@@ -276,7 +276,7 @@ mod test {
             .await
             .expect("Can add account");
 
-        let key_bundle = create_publish_key_bundle(
+        let key_bundle = create_publish_pre_keys(
             Some(vec![1, 2]),
             Some(1),
             Some(vec![1, 2]),
@@ -344,7 +344,7 @@ mod test {
             .await
             .expect("Alice can add device");
 
-        let key_bundle = create_publish_key_bundle(
+        let key_bundle = create_publish_pre_keys(
             Some(vec![1, 2]),
             Some(22),
             Some(vec![1, 2]),

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -3,7 +3,7 @@ use sam_server::{start_server, state::ServerState, ServerConfig};
 #[tokio::main]
 pub async fn main() {
     env_logger::init();
-    let state = ServerState::in_memory("test".to_string(), 10);
+    let state = ServerState::in_memory("test".to_string(), 600, 10);
 
     let config = ServerConfig {
         state,

--- a/server/src/managers/in_memory/device.rs
+++ b/server/src/managers/in_memory/device.rs
@@ -77,7 +77,7 @@ impl DeviceManager for InMemoryDeviceManager {
     }
 
     async fn provision_expire_seconds(&self) -> Result<u64, ServerError> {
-        Ok(self.provision_expire_seconds.clone())
+        Ok(self.provision_expire_seconds)
     }
 
     async fn add_device(

--- a/server/src/managers/in_memory/device.rs
+++ b/server/src/managers/in_memory/device.rs
@@ -16,14 +16,16 @@ pub struct InMemoryDeviceManager {
     devices: Arc<Mutex<HashMap<DeviceAddress, Device>>>,
     account_devices: Arc<Mutex<HashMap<AccountId, HashSet<DeviceAddress>>>>,
     link_secret: String,
+    provision_expire_seconds: u64,
 }
 
 impl InMemoryDeviceManager {
-    pub fn new(link_secret: String) -> Self {
+    pub fn new(link_secret: String, provision_expire_seconds: u64) -> Self {
         InMemoryDeviceManager {
             devices: Arc::new(Mutex::new(HashMap::new())),
             account_devices: Arc::new(Mutex::new(HashMap::new())),
             link_secret,
+            provision_expire_seconds,
         }
     }
 }
@@ -72,6 +74,10 @@ impl DeviceManager for InMemoryDeviceManager {
 
     async fn link_secret(&self) -> Result<String, ServerError> {
         Ok(self.link_secret.clone())
+    }
+
+    async fn provision_expire_seconds(&self) -> Result<u64, ServerError> {
+        Ok(self.provision_expire_seconds.clone())
     }
 
     async fn add_device(

--- a/server/src/managers/in_memory/mod.rs
+++ b/server/src/managers/in_memory/mod.rs
@@ -25,10 +25,14 @@ impl StateType for InMemStateType {
 }
 
 impl ServerState<InMemStateType> {
-    pub fn in_memory(link_secret: String, message_buffer: usize) -> Self {
+    pub fn in_memory(
+        link_secret: String,
+        provision_expire_seconds: u64, // signal uses 600 seconds
+        message_buffer: usize,
+    ) -> Self {
         ServerState::new(
             InMemoryAccountManager::default(),
-            InMemoryDeviceManager::new(link_secret),
+            InMemoryDeviceManager::new(link_secret, provision_expire_seconds),
             InMemoryMessageManager::new(message_buffer),
             InMemoryKeyManager::default(),
         )
@@ -40,7 +44,7 @@ impl ServerState<InMemStateType> {
 
         ServerState::new(
             InMemoryAccountManager::default(),
-            InMemoryDeviceManager::new(LINK_SECRET.to_string()),
+            InMemoryDeviceManager::new(LINK_SECRET.to_string(), 600),
             InMemoryMessageManager::default(),
             InMemoryKeyManager::default(),
         )

--- a/server/src/managers/traits/device_manager.rs
+++ b/server/src/managers/traits/device_manager.rs
@@ -8,6 +8,7 @@ pub trait DeviceManager: Send + Sync + Clone {
     async fn get_devices(&self, account_id: AccountId) -> Result<Vec<DeviceId>, ServerError>;
     async fn next_device_id(&self, account_id: AccountId) -> Result<DeviceId, ServerError>;
     async fn link_secret(&self) -> Result<String, ServerError>;
+    async fn provision_expire_seconds(&self) -> Result<u64, ServerError>;
     async fn add_device(
         &mut self,
         account_id: AccountId,

--- a/server/src/managers/traits/key_manager.rs
+++ b/server/src/managers/traits/key_manager.rs
@@ -17,7 +17,7 @@ pub trait PreKeyManager: Send + Sync + Clone {
         &self,
         account_id: AccountId,
         device_id: DeviceId,
-    ) -> Result<Vec<u32>, ServerError>;
+    ) -> Result<Option<Vec<u32>>, ServerError>;
     async fn add_pre_key(
         &mut self,
         account_id: AccountId,
@@ -64,7 +64,7 @@ pub trait PqPreKeyManager {
         &self,
         account_id: AccountId,
         device_id: DeviceId,
-    ) -> Result<Vec<u32>, ServerError>;
+    ) -> Result<Option<Vec<u32>>, ServerError>;
     async fn add_pq_pre_key(
         &mut self,
         account_id: AccountId,

--- a/server/src/routes/account.rs
+++ b/server/src/routes/account.rs
@@ -38,6 +38,9 @@ async fn delete_account_endpoint<T: StateType>(
     State(mut state): State<ServerState<T>>,
     auth_user: AuthenticatedUser,
 ) -> Result<(), ServerError> {
+    if *auth_user.device().id() != 1 {
+        return Err(ServerError::DeviceUnAuth);
+    }
     delete_account(&mut state, auth_user.account().id()).await
 }
 
@@ -45,4 +48,110 @@ pub fn account_routes<T: StateType>(router: Router<ServerState<T>>) -> Router<Se
     router
         .route("/api/v1/account", post(account_register_endpoint))
         .route("/api/v1/account", delete(delete_account_endpoint))
+}
+
+#[cfg(test)]
+mod test {
+    use axum::http;
+    use base64::{prelude::BASE64_STANDARD, Engine};
+    use libsignal_protocol::IdentityKeyPair;
+    use rand::rngs::OsRng;
+    use sam_common::api::{
+        device::DeviceActivationInfo, RegistrationRequest, RegistrationResponse,
+    };
+
+    use crate::{
+        managers::traits::{
+            account_manager::AccountManager,
+            key_manager::{LastResortKeyManager, SignedPreKeyManager},
+        },
+        routes::{
+            account::account_routes,
+            test_utils::{create_user, test_server},
+        },
+        state::ServerState,
+        test_utils::{create_publish_pre_keys, pq_pre_key, signed_ec_pre_key},
+    };
+
+    #[tokio::test]
+    async fn test_post_api_v1_account() {
+        let state = ServerState::in_memory_test();
+
+        let server = test_server(state.clone(), account_routes);
+
+        let id_pair = IdentityKeyPair::generate(&mut OsRng);
+        let basic = format!("Basic {}", BASE64_STANDARD.encode("alice:password"));
+
+        let reg_request = RegistrationRequest {
+            identity_key: *id_pair.identity_key(),
+            device_activation: DeviceActivationInfo {
+                name: "phone".to_string(),
+                registration_id: 1.into(),
+                key_bundle: create_publish_pre_keys(
+                    Some(vec![1]),
+                    Some(3),
+                    Some(vec![4]),
+                    Some(33),
+                    &id_pair,
+                    OsRng,
+                )
+                .try_into()
+                .expect("Can make RegistrationPreKeys"),
+            },
+        };
+
+        let res = server
+            .post("/api/v1/account")
+            .add_header(http::header::AUTHORIZATION, basic)
+            .json(&reg_request)
+            .await;
+        let json_res = res.json::<RegistrationResponse>();
+        res.assert_status_ok();
+        assert!(state
+            .accounts
+            .get_account(json_res.account_id)
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_delete_api_v1_account() {
+        let mut state = ServerState::in_memory_test();
+        let (pair, account_id, device_id) =
+            create_user(&mut state, "alice", "phone", "password", OsRng).await;
+
+        state
+            .keys
+            .set_last_resort_key(
+                account_id,
+                device_id,
+                pair.identity_key(),
+                pq_pre_key(1, &pair),
+            )
+            .await
+            .expect("Can set key");
+
+        state
+            .keys
+            .set_signed_pre_key(
+                account_id,
+                device_id,
+                pair.identity_key(),
+                signed_ec_pre_key(2, &pair, OsRng),
+            )
+            .await
+            .expect("Can set signed prekey");
+
+        let server = test_server(state.clone(), account_routes);
+        let basic = format!(
+            "Basic {}",
+            BASE64_STANDARD.encode(format!("{account_id}.1:password"))
+        );
+
+        let res = server
+            .delete("/api/v1/account")
+            .add_header(http::header::AUTHORIZATION, basic)
+            .await;
+        res.assert_status_ok();
+    }
 }

--- a/server/src/routes/device.rs
+++ b/server/src/routes/device.rs
@@ -50,6 +50,9 @@ async fn delete_device_endpoint<T: StateType>(
     Path(device_id): Path<DeviceId>,
     auth_user: AuthenticatedUser,
 ) -> Result<(), ServerError> {
+    if *auth_user.device().id() == 1 && auth_user.device().id() != device_id {
+        return Err(ServerError::DeviceUnAuth);
+    }
     unlink_device(&mut state, auth_user.account().id(), device_id).await
 }
 
@@ -61,4 +64,140 @@ pub fn device_routes<T: StateType>(router: Router<ServerState<T>>) -> Router<Ser
         )
         .route("/api/v1/devices/link", post(link_device_endpoint))
         .route("/api/v1/device/{id}", delete(delete_device_endpoint))
+}
+
+#[cfg(test)]
+mod test {
+    use std::time::Duration;
+
+    use axum::http::{self, StatusCode};
+    use base64::{prelude::BASE64_STANDARD, Engine};
+    use rand::rngs::OsRng;
+    use rstest::rstest;
+    use sam_common::api::{device::DeviceActivationInfo, LinkDeviceRequest, LinkDeviceToken};
+
+    use crate::{
+        auth::password::Password,
+        managers::{
+            entities::device::Device, in_memory::test_utils::LINK_SECRET,
+            traits::device_manager::DeviceManager,
+        },
+        routes::{
+            device::device_routes,
+            test_utils::{create_user, test_server},
+        },
+        state::ServerState,
+        test_utils::create_publish_pre_keys,
+    };
+
+    #[tokio::test]
+    async fn test_get_api_v1_devices_provision() {
+        let mut state = ServerState::in_memory_test();
+
+        let (_, account_id, _) = create_user(&mut state, "alice", "phone", "password", OsRng).await;
+
+        let server = test_server(state.clone(), device_routes);
+        let basic = format!(
+            "Basic {}",
+            BASE64_STANDARD.encode(format!("{account_id}.1:password"))
+        );
+
+        let res = server
+            .get("/api/v1/devices/provision")
+            .add_header(http::header::AUTHORIZATION, basic)
+            .await;
+        res.assert_status_ok();
+    }
+
+    #[rstest]
+    #[case(600, StatusCode::OK, true)]
+    #[case(0, StatusCode::FORBIDDEN, false)]
+    #[tokio::test]
+    async fn test_get_api_v1_devices_link(
+        #[case] expire_time: u64,
+        #[case] expected_status: StatusCode,
+        #[case] expects_ok_device: bool,
+    ) {
+        let mut state = ServerState::in_memory(LINK_SECRET.to_string(), expire_time, 10);
+
+        let (pair, account_id, _) =
+            create_user(&mut state, "alice", "phone", "password", OsRng).await;
+
+        let server = test_server(state.clone(), device_routes);
+        let basic = format!(
+            "Basic {}",
+            BASE64_STANDARD.encode(format!("{account_id}.1:password"))
+        );
+
+        let res = server
+            .get("/api/v1/devices/provision")
+            .add_header(http::header::AUTHORIZATION, basic)
+            .await;
+
+        let token = res.json::<LinkDeviceToken>();
+        let req = LinkDeviceRequest {
+            token,
+            device_activation: DeviceActivationInfo {
+                name: "car".to_string(),
+                registration_id: 2.into(),
+                key_bundle: create_publish_pre_keys(None, Some(66), None, Some(33), &pair, OsRng)
+                    .try_into()
+                    .expect("Can make RegistrationPreKeys"),
+            },
+        };
+
+        // this request is be made by provisioned device
+        let basic = format!(
+            "Basic {}",
+            BASE64_STANDARD.encode(format!("{account_id}:otherpass"))
+        );
+
+        if expire_time == 0 {
+            tokio::time::sleep(Duration::from_secs(2)).await
+        }
+
+        let res = server
+            .post("/api/v1/devices/link")
+            .add_header(http::header::AUTHORIZATION, basic)
+            .json(&req)
+            .await;
+        res.assert_status(expected_status);
+        assert!(state.devices.get_device(account_id, 2.into()).await.is_ok() == expects_ok_device);
+    }
+
+    #[tokio::test]
+    async fn test_delete_api_v1_device_id() {
+        let mut state = ServerState::in_memory_test();
+
+        let (_, account_id, _) = create_user(&mut state, "alice", "phone", "password", OsRng).await;
+        state
+            .devices
+            .add_device(
+                account_id,
+                &Device::builder()
+                    .creation(0)
+                    .id(2.into())
+                    .registration_id(1.into())
+                    .name("microwave".to_string())
+                    .password(
+                        Password::generate("otherpass".to_string())
+                            .expect("Password can be generated"),
+                    )
+                    .build(),
+            )
+            .await
+            .expect("Can Add Device");
+
+        let server = test_server(state.clone(), device_routes);
+        let basic = format!(
+            "Basic {}",
+            BASE64_STANDARD.encode(format!("{account_id}.2:otherpass"))
+        );
+
+        let res = server
+            .delete("/api/v1/device/2")
+            .add_header(http::header::AUTHORIZATION, basic)
+            .await;
+        res.assert_status_ok();
+    }
 }

--- a/server/src/routes/keys.rs
+++ b/server/src/routes/keys.rs
@@ -127,12 +127,11 @@ mod test {
             bundles: vec![PreKeyBundle {
                 device_id: 1,
                 registration_id: 1,
-                pre_key: keys.pre_keys.unwrap().first().map(|k| k.clone()),
+                pre_key: keys.pre_keys.unwrap().first().cloned(),
                 pq_pre_key: keys
                     .pq_pre_keys
                     .unwrap()
-                    .first()
-                    .map(|k| k.clone())
+                    .first().cloned()
                     .unwrap(),
                 signed_pre_key: keys.signed_pre_key.unwrap(),
             }],

--- a/server/src/routes/keys.rs
+++ b/server/src/routes/keys.rs
@@ -18,6 +18,7 @@ use crate::{
 /// Returns key bundles for users devices
 pub async fn keys_bundles_endpoint<T: StateType>(
     Path(account_id): Path<AccountId>,
+    _auth_user: AuthenticatedUser,
     State(mut state): State<ServerState<T>>,
 ) -> Result<Json<PreKeyBundles>, ServerError> {
     get_keybundles(&mut state, account_id).await.map(Json)
@@ -46,23 +47,23 @@ pub fn key_routes<T: StateType>(router: Router<ServerState<T>>) -> Router<Server
 
 #[cfg(test)]
 mod test {
-    use axum::http::{self, StatusCode};
-    use base64::{prelude::BASE64_STANDARD, Engine};
-    use rand::rngs::OsRng;
-
     use crate::{
-        managers::in_memory::test_utils::LINK_SECRET,
+        logic::keys::add_keybundle,
         routes::{
             keys::key_routes,
             test_utils::{create_user, test_server},
         },
         state::ServerState,
-        test_utils::create_publish_key_bundle,
+        test_utils::create_publish_pre_keys,
     };
+    use axum::http;
+    use base64::{prelude::BASE64_STANDARD, Engine};
+    use rand::rngs::OsRng;
+    use sam_common::api::{keys::PreKeyBundles, PreKeyBundle};
 
     #[tokio::test]
-    async fn test_publish_keys() {
-        let mut state = ServerState::in_memory(LINK_SECRET.to_owned(), 10);
+    async fn test_post_api_v1_keys() {
+        let mut state = ServerState::in_memory_test();
         let (pair, account_id, _) = create_user(&mut state, "alice", "phone", "bob", OsRng).await;
 
         let server = test_server(state, key_routes);
@@ -74,7 +75,7 @@ mod test {
         let res = server
             .put("/api/v1/keys")
             .add_header(http::header::AUTHORIZATION, basic)
-            .json(&create_publish_key_bundle(
+            .json(&create_publish_pre_keys(
                 Some(vec![1]),
                 Some(3),
                 Some(vec![4]),
@@ -83,6 +84,61 @@ mod test {
                 OsRng,
             ))
             .await;
-        res.assert_status(StatusCode::OK);
+        res.assert_status_ok();
+    }
+
+    #[tokio::test]
+    async fn test_get_api_v1_keys_account() {
+        let mut state = ServerState::in_memory_test();
+        let (pair, account_id, device_id) =
+            create_user(&mut state, "alice", "phone", "bob", OsRng).await;
+
+        let keys = create_publish_pre_keys(
+            Some(vec![1]),
+            Some(3),
+            Some(vec![4]),
+            Some(33),
+            &pair,
+            OsRng,
+        );
+        add_keybundle(
+            &mut state,
+            pair.identity_key(),
+            account_id,
+            device_id,
+            keys.clone(),
+        )
+        .await
+        .expect("Can add keys");
+
+        let server = test_server(state, key_routes);
+        let basic = format!(
+            "Basic {}",
+            BASE64_STANDARD.encode(format!("{}.1:{}", account_id, "bob"))
+        );
+
+        let res = server
+            .get(&format!("/api/v1/keys/{account_id}"))
+            .add_header(http::header::AUTHORIZATION, basic)
+            .await;
+
+        let expected = PreKeyBundles {
+            identity_key: *pair.identity_key(),
+            bundles: vec![PreKeyBundle {
+                device_id: 1,
+                registration_id: 1,
+                pre_key: keys.pre_keys.unwrap().first().map(|k| k.clone()),
+                pq_pre_key: keys
+                    .pq_pre_keys
+                    .unwrap()
+                    .first()
+                    .map(|k| k.clone())
+                    .unwrap(),
+                signed_pre_key: keys.signed_pre_key.unwrap(),
+            }],
+        };
+
+        res.assert_status_ok();
+        res.assert_json(&expected);
     }
 }

--- a/server/src/routes/keys.rs
+++ b/server/src/routes/keys.rs
@@ -128,11 +128,7 @@ mod test {
                 device_id: 1,
                 registration_id: 1,
                 pre_key: keys.pre_keys.unwrap().first().cloned(),
-                pq_pre_key: keys
-                    .pq_pre_keys
-                    .unwrap()
-                    .first().cloned()
-                    .unwrap(),
+                pq_pre_key: keys.pq_pre_keys.unwrap().first().cloned().unwrap(),
                 signed_pre_key: keys.signed_pre_key.unwrap(),
             }],
         };

--- a/server/src/routes/websocket.rs
+++ b/server/src/routes/websocket.rs
@@ -58,7 +58,6 @@ mod test {
     };
 
     use crate::{
-        managers::in_memory::test_utils::LINK_SECRET,
         routes::{test_utils::create_user, websocket::websocket_routes},
         state::{state_type::StateType, ServerState},
     };
@@ -106,7 +105,7 @@ mod test {
 
     #[tokio::test]
     async fn test_websocket_alice_send_to_bob() {
-        let mut state = ServerState::in_memory(LINK_SECRET.to_owned(), 10);
+        let mut state = ServerState::in_memory_test();
         let (_, alice_id, alice_device) =
             create_user(&mut state, "alice", "phone", "bob", OsRng).await;
         let (_, bob_id, bob_device) =
@@ -163,7 +162,7 @@ mod test {
 
     #[tokio::test]
     async fn test_websocket_alice_send_to_bob_offline() {
-        let mut state = ServerState::in_memory(LINK_SECRET.to_owned(), 10);
+        let mut state = ServerState::in_memory_test();
         let (_, alice_id, alice_device) =
             create_user(&mut state, "alice", "phone", "bob", OsRng).await;
         let (_, bob_id, bob_device) =

--- a/server/src/test_utils.rs
+++ b/server/src/test_utils.rs
@@ -6,8 +6,9 @@ use rand::rngs::OsRng;
 use sam_common::{
     address::RegistrationId,
     api::{
-        device::DeviceActivationInfo, keys::PublishPreKeys, EcPreKey, LinkDeviceRequest,
-        LinkDeviceToken, PqPreKey, SignedEcPreKey,
+        device::DeviceActivationInfo,
+        keys::{PublishPreKeys, RegistrationPreKeys},
+        EcPreKey, LinkDeviceRequest, LinkDeviceToken, PqPreKey, SignedEcPreKey,
     },
     time_now_millis,
 };
@@ -16,7 +17,7 @@ pub fn create_device_link(
     token: LinkDeviceToken,
     name: &str,
     registration_id: RegistrationId,
-    key_bundle: PublishPreKeys,
+    key_bundle: RegistrationPreKeys,
 ) -> LinkDeviceRequest {
     LinkDeviceRequest {
         token,
@@ -28,7 +29,7 @@ pub fn create_device_link(
     }
 }
 
-pub fn create_publish_key_bundle(
+pub fn create_publish_pre_keys(
     pre_key_ids: Option<Vec<u32>>,
     signed_pre_key_id: Option<u32>,
     pq_pre_key_ids: Option<Vec<u32>>,


### PR DESCRIPTION
This pull requests adds tests to all routes and fixes some mistakes found while testing:
- Added `RegistrationPreKeys` where last resort and signed pre key are mandatory
  - used when linking new device and registration, publishing keys are still optionals
- Provisioning time is now configurable
- key manager returns `Option` when getting keys that may be depleted 
- GET `/api/v1/keys/{account_id}` now requires authorization header