### PR TITLE
Added key bundle endpoint for single device

### DIFF
--- a/server/src/logic/keys.rs
+++ b/server/src/logic/keys.rs
@@ -1,6 +1,6 @@
 use libsignal_protocol::IdentityKey;
 use sam_common::{
-    address::{AccountId, DeviceId, RegistrationId},
+    address::{AccountId, DeviceId},
     api::keys::{Key, PreKeyBundle, PreKeyBundles, PublishPreKeys},
 };
 
@@ -17,9 +17,13 @@ use crate::{
 pub async fn get_keybundle<T: StateType>(
     state: &mut ServerState<T>,
     account_id: AccountId,
-    registration_id: RegistrationId,
     device_id: DeviceId,
 ) -> Result<PreKeyBundle, ServerError> {
+    let registration_id = state
+        .devices
+        .get_device(account_id, device_id)
+        .await?
+        .registration_id();
     let pre_key = state.keys.get_pre_key(account_id, device_id).await?;
     let pq_pre_key = state.keys.get_pq_pre_key(account_id, device_id).await?;
     let signed_pre_key = state.keys.get_signed_pre_key(account_id, device_id).await?;
@@ -118,9 +122,7 @@ pub async fn get_keybundles<T: StateType>(
     let bundles = {
         let mut bundle_vec = vec![];
         for device in devices {
-            bundle_vec.push(
-                get_keybundle(state, account_id, device.registration_id(), device.id()).await?,
-            );
+            bundle_vec.push(get_keybundle(state, account_id, device.id()).await?);
         }
         bundle_vec
     };
@@ -219,7 +221,32 @@ mod test {
         let mut rng = OsRng;
         let pair = IdentityKeyPair::generate(&mut rng);
 
-        let account_id = AccountId::generate();
+        let account = Account::builder()
+            .id(AccountId::generate())
+            .identity(*pair.identity_key())
+            .username("Alice".to_string())
+            .build();
+
+        state
+            .accounts
+            .add_account(&account)
+            .await
+            .expect("Can add account");
+
+        let device = Device::builder()
+            .id(1.into())
+            .name("Alice Secret Phone".to_string())
+            .password(Password::generate("dave<3".to_string()).expect("Alice can create password"))
+            .creation(0)
+            .registration_id(1.into())
+            .build();
+
+        let account_id = account.id();
+        state
+            .devices
+            .add_device(account_id, &device)
+            .await
+            .expect("Alice can add device");
 
         let key_bundle = create_publish_pre_keys(
             Some(vec![1, 2]),
@@ -241,7 +268,7 @@ mod test {
         .expect("User can create key bundle");
 
         // testing if we get keys
-        let bundle = get_keybundle(&mut state, account_id, 1.into(), 1.into())
+        let bundle = get_keybundle(&mut state, account_id, 1.into())
             .await
             .expect("User have uploaded bundles");
 
@@ -252,7 +279,7 @@ mod test {
         assert!(bundle.pq_pre_key.id() == 1);
 
         // testing if we get last resort key
-        let bundle = get_keybundle(&mut state, account_id, 1.into(), 1.into())
+        let bundle = get_keybundle(&mut state, account_id, 1.into())
             .await
             .expect("User have uploaded bundles");
         assert!(bundle.pq_pre_key.id() == 33)

--- a/server/src/routes/keys.rs
+++ b/server/src/routes/keys.rs
@@ -5,23 +5,36 @@ use axum::{
 };
 use sam_common::{
     address::AccountId,
-    api::keys::{PreKeyBundles, PublishPreKeys},
+    api::{
+        keys::{PreKeyBundles, PublishPreKeys},
+        PreKeyBundle,
+    },
+    DeviceId,
 };
 
 use crate::{
     auth::authenticated_user::AuthenticatedUser,
-    logic::keys::{get_keybundles, publish_keybundle},
+    logic::keys::{get_keybundle, get_keybundles, publish_keybundle},
     state::{state_type::StateType, ServerState},
     ServerError,
 };
 
 /// Returns key bundles for users devices
-pub async fn keys_bundles_endpoint<T: StateType>(
+pub async fn key_bundles_endpoint<T: StateType>(
     Path(account_id): Path<AccountId>,
     _auth_user: AuthenticatedUser,
     State(mut state): State<ServerState<T>>,
 ) -> Result<Json<PreKeyBundles>, ServerError> {
     get_keybundles(&mut state, account_id).await.map(Json)
+}
+
+pub async fn key_bundle_endpoint<T: StateType>(
+    Path((account_id, device_id)): Path<(AccountId, DeviceId)>,
+    State(mut state): State<ServerState<T>>,
+) -> Result<Json<PreKeyBundle>, ServerError> {
+    get_keybundle(&mut state, account_id, device_id)
+        .await
+        .map(Json)
 }
 
 /// Handle publish of new key bundles
@@ -41,7 +54,11 @@ async fn publish_keys_endpoint<T: StateType>(
 
 pub fn key_routes<T: StateType>(router: Router<ServerState<T>>) -> Router<ServerState<T>> {
     router
-        .route("/api/v1/keys/{account_id}", get(keys_bundles_endpoint))
+        .route("/api/v1/keys/{account_id}", get(key_bundles_endpoint))
+        .route(
+            "/api/v1/keys/{account_id}/{device_id}",
+            get(key_bundle_endpoint),
+        )
         .route("/api/v1/keys", put(publish_keys_endpoint))
 }
 
@@ -131,6 +148,53 @@ mod test {
                 pq_pre_key: keys.pq_pre_keys.unwrap().first().cloned().unwrap(),
                 signed_pre_key: keys.signed_pre_key.unwrap(),
             }],
+        };
+
+        res.assert_status_ok();
+        res.assert_json(&expected);
+    }
+
+    #[tokio::test]
+    async fn test_get_api_v1_keys_account_device() {
+        let mut state = ServerState::in_memory_test();
+        let (pair, account_id, device_id) =
+            create_user(&mut state, "alice", "phone", "bob", OsRng).await;
+
+        let keys = create_publish_pre_keys(
+            Some(vec![1]),
+            Some(3),
+            Some(vec![4]),
+            Some(33),
+            &pair,
+            OsRng,
+        );
+        add_keybundle(
+            &mut state,
+            pair.identity_key(),
+            account_id,
+            device_id,
+            keys.clone(),
+        )
+        .await
+        .expect("Can add keys");
+
+        let server = test_server(state, key_routes);
+        let basic = format!(
+            "Basic {}",
+            BASE64_STANDARD.encode(format!("{}.1:{}", account_id, "bob"))
+        );
+
+        let res = server
+            .get(&format!("/api/v1/keys/{account_id}/{device_id}"))
+            .add_header(http::header::AUTHORIZATION, basic)
+            .await;
+
+        let expected = PreKeyBundle {
+            device_id: 1,
+            registration_id: 1,
+            pre_key: keys.pre_keys.unwrap().first().cloned(),
+            pq_pre_key: keys.pq_pre_keys.unwrap().first().cloned().unwrap(),
+            signed_pre_key: keys.signed_pre_key.unwrap(),
         };
 
         res.assert_status_ok();

--- a/server/src/routes/keys.rs
+++ b/server/src/routes/keys.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 /// Returns key bundles for users devices
-pub async fn key_bundles_endpoint<T: StateType>(
+async fn key_bundles_endpoint<T: StateType>(
     Path(account_id): Path<AccountId>,
     _auth_user: AuthenticatedUser,
     State(mut state): State<ServerState<T>>,
@@ -28,7 +28,7 @@ pub async fn key_bundles_endpoint<T: StateType>(
     get_keybundles(&mut state, account_id).await.map(Json)
 }
 
-pub async fn key_bundle_endpoint<T: StateType>(
+async fn key_bundle_endpoint<T: StateType>(
     Path((account_id, device_id)): Path<(AccountId, DeviceId)>,
     State(mut state): State<ServerState<T>>,
 ) -> Result<Json<PreKeyBundle>, ServerError> {


### PR DESCRIPTION
Adds an endpoint, `/api/v1/keys/{account_id}/{device_id}`, that returns a keybundle for a single device.