### PR TITLE
Global Timeout for Message E2E

### DIFF
--- a/e2e/tests/message.rs
+++ b/e2e/tests/message.rs
@@ -17,6 +17,8 @@ use tokio::time::timeout;
 
 use crate::utils::server::TestServer;
 
+const TIMEOUT_SECS: u64 = 120;
+
 async fn client(
     address: &str,
     username: &str,
@@ -59,222 +61,231 @@ async fn client_device(
 
 #[tokio::test]
 async fn test_alice_send_to_bob() {
-    let address = "127.0.0.1:9180";
-    let mut server = TestServer::start(address).await;
-    server
-        .started_rx()
-        .await
-        .expect("Should be able to start server");
+    timeout(Duration::from_secs(TIMEOUT_SECS), async {
+        let address = "127.0.0.1:9180";
+        let mut server = TestServer::start(address).await;
+        server
+            .started_rx()
+            .await
+            .expect("Should be able to start server");
 
-    let mut alice = client(address, "alice", "alice device").await;
-    let mut bob = client(address, "bob", "bob device").await;
+        let mut alice = client(address, "alice", "alice device").await;
+        let mut bob = client(address, "bob", "bob device").await;
 
-    let bob_id = bob.account_id().await.expect("Bob can get his id");
+        let bob_id = bob.account_id().await.expect("Bob can get his id");
 
-    let mut bob_recv = bob.subscribe();
-    alice
-        .fetch_prekeys(bob_id, None)
-        .await
-        .expect("Can fetch bob keys");
-    let status = alice
-        .send_message(bob_id, "Hello bob!")
-        .await
-        .expect("Alice can send message");
+        let mut bob_recv = bob.subscribe();
+        alice
+            .fetch_prekeys(bob_id, None)
+            .await
+            .expect("Can fetch bob keys");
+        let status = alice
+            .send_message(bob_id, "Hello bob!")
+            .await
+            .expect("Alice can send message");
 
-    bob.process_messages()
-        .await
-        .expect("Bob can process messages");
+        bob.process_messages()
+            .await
+            .expect("Bob can process messages");
 
-    let res = timeout(Duration::from_millis(300), bob_recv.recv())
-        .await
-        .expect("Bob receives message in time")
-        .expect("receiver works");
+        let res = bob_recv.recv().await.expect("receiver works");
 
-    let msg = String::from_utf8_lossy(res.content_bytes());
+        let msg = String::from_utf8_lossy(res.content_bytes());
 
-    assert!(matches!(status, MessageStatus::Ok));
-    assert!(msg == "Hello bob!")
+        assert!(matches!(status, MessageStatus::Ok));
+        assert!(msg == "Hello bob!")
+    })
+    .await
+    .expect("Test took to long to complete")
 }
 
 #[tokio::test]
 async fn test_alice_send_to_bob_offline() {
-    let address = "127.0.0.1:9181";
-    let mut server = TestServer::start(address).await;
-    server
-        .started_rx()
-        .await
-        .expect("Should be able to start server");
+    timeout(Duration::from_secs(TIMEOUT_SECS), async {
+        let address = "127.0.0.1:9181";
+        let mut server = TestServer::start(address).await;
+        server
+            .started_rx()
+            .await
+            .expect("Should be able to start server");
 
-    let mut alice = client(address, "alice", "alice device").await;
-    let mut bob = client(address, "bob", "bob device").await;
+        let mut alice = client(address, "alice", "alice device").await;
+        let mut bob = client(address, "bob", "bob device").await;
 
-    let bob_id = bob.account_id().await.expect("Bob can get his id");
+        let bob_id = bob.account_id().await.expect("Bob can get his id");
 
-    bob.disconnect().await.expect("Bob can disconnect");
+        bob.disconnect().await.expect("Bob can disconnect");
 
-    alice
-        .fetch_prekeys(bob_id, None)
-        .await
-        .expect("Can fetch bob keys");
-    let status = alice
-        .send_message(bob_id, "Hello bob!")
-        .await
-        .expect("Alice can send message");
+        alice
+            .fetch_prekeys(bob_id, None)
+            .await
+            .expect("Can fetch bob keys");
+        let status = alice
+            .send_message(bob_id, "Hello bob!")
+            .await
+            .expect("Alice can send message");
 
-    bob.connect().await.expect("Bob can connect");
+        bob.connect().await.expect("Bob can connect");
 
-    let mut bob_recv = bob.subscribe();
+        let mut bob_recv = bob.subscribe();
 
-    let process_timeout = timeout(Duration::from_secs(1), bob.process_messages_blocking()).await;
+        bob.process_messages_blocking()
+            .await
+            .expect("Bob processes messages");
 
-    assert!(matches!(process_timeout, Ok(Ok(()))));
+        let res = bob_recv.recv().await.expect("receiver works");
 
-    let res = timeout(Duration::from_millis(300), bob_recv.recv())
-        .await
-        .expect("Bob receives message in time")
-        .expect("receiver works");
+        let msg = String::from_utf8_lossy(res.content_bytes());
 
-    let msg = String::from_utf8_lossy(res.content_bytes());
-
-    assert!(matches!(status, MessageStatus::Ok));
-    assert!(msg == "Hello bob!")
+        assert!(matches!(status, MessageStatus::Ok));
+        assert!(msg == "Hello bob!")
+    })
+    .await
+    .expect("Test took to long to complete")
 }
 
 #[tokio::test]
-async fn alice_send_to_bob_missing_devices() {
-    let address = "127.0.0.1:9181";
-    let mut server = TestServer::start(address).await;
-    server
-        .started_rx()
-        .await
-        .expect("Should be able to start server");
+async fn test_alice_send_to_bob_missing_devices() {
+    timeout(Duration::from_secs(TIMEOUT_SECS), async {
+        let address = "127.0.0.1:9181";
+        let mut server = TestServer::start(address).await;
+        server
+            .started_rx()
+            .await
+            .expect("Should be able to start server");
 
-    let mut alice = client(address, "alice", "alice device").await;
-    let mut bob = client(address, "bob", "bob device").await;
+        let mut alice = client(address, "alice", "alice device").await;
+        let mut bob = client(address, "bob", "bob device").await;
 
-    let token = bob
-        .create_provision()
-        .await
-        .expect("bob can init provisioning");
-    let bob_id = bob.account_id().await.expect("Bob can get account id");
-    bob.disconnect().await.expect("bob can disconnect");
+        let token = bob
+            .create_provision()
+            .await
+            .expect("bob can init provisioning");
+        let bob_id = bob.account_id().await.expect("Bob can get account id");
+        bob.disconnect().await.expect("bob can disconnect");
 
-    alice
-        .fetch_prekeys(bob_id, None)
-        .await
-        .expect("Can fetch bob keys");
-    let _bob_device = client_device(
-        address,
-        "bob_device",
-        bob.identity_key_pair().await.expect("can get id pair"),
-        token,
-    )
-    .await;
+        alice
+            .fetch_prekeys(bob_id, None)
+            .await
+            .expect("Can fetch bob keys");
+        let _bob_device = client_device(
+            address,
+            "bob_device",
+            bob.identity_key_pair().await.expect("can get id pair"),
+            token,
+        )
+        .await;
 
-    let status = alice
-        .send_message(bob_id, "Hello bob!")
-        .await
-        .expect("Alice can send message");
+        let status = alice
+            .send_message(bob_id, "Hello bob!")
+            .await
+            .expect("Alice can send message");
 
-    assert!(matches!(status, MessageStatus::MissingDevices(_)))
+        assert!(matches!(status, MessageStatus::MissingDevices(_)))
+    })
+    .await
+    .expect("Test took to long to complete")
 }
 
 #[tokio::test]
-async fn alice_send_to_bob_two_devices() {
-    let address = "127.0.0.1:9181";
-    let mut server = TestServer::start(address).await;
-    server
-        .started_rx()
-        .await
-        .expect("Should be able to start server");
+async fn test_alice_send_to_bob_two_devices() {
+    timeout(Duration::from_secs(TIMEOUT_SECS), async {
+        let address = "127.0.0.1:9181";
+        let mut server = TestServer::start(address).await;
+        server
+            .started_rx()
+            .await
+            .expect("Should be able to start server");
 
-    let mut alice = client(address, "alice", "alice device").await;
-    let mut bob = client(address, "bob", "bob device").await;
+        let mut alice = client(address, "alice", "alice device").await;
+        let mut bob = client(address, "bob", "bob device").await;
 
-    let token = bob
-        .create_provision()
-        .await
-        .expect("bob can init provisioning");
-    let bob_id = bob.account_id().await.expect("Bob can get account id");
+        let token = bob
+            .create_provision()
+            .await
+            .expect("bob can init provisioning");
+        let bob_id = bob.account_id().await.expect("Bob can get account id");
 
-    let mut bob_device = client_device(
-        address,
-        "bob_device",
-        bob.identity_key_pair().await.expect("can get id pair"),
-        token,
-    )
-    .await;
-    alice
-        .fetch_prekeys(bob_id, None)
-        .await
-        .expect("Can fetch bob keys");
+        let mut bob_device = client_device(
+            address,
+            "bob_device",
+            bob.identity_key_pair().await.expect("can get id pair"),
+            token,
+        )
+        .await;
+        alice
+            .fetch_prekeys(bob_id, None)
+            .await
+            .expect("Can fetch bob keys");
 
-    let status = alice
-        .send_message(bob_id, "Hello bob!")
-        .await
-        .expect("Alice can send message");
+        let status = alice
+            .send_message(bob_id, "Hello bob!")
+            .await
+            .expect("Alice can send message");
 
-    let mut bob_device_recv = bob_device.subscribe();
-    let mut bob_recv = bob.subscribe();
+        let mut bob_device_recv = bob_device.subscribe();
+        let mut bob_recv = bob.subscribe();
 
-    bob.process_messages()
-        .await
-        .expect("Bob can process messages");
-    bob_device
-        .process_messages()
-        .await
-        .expect("Bob device can process messages");
+        bob.process_messages_blocking()
+            .await
+            .expect("Bob can process messages");
+        bob_device
+            .process_messages_blocking()
+            .await
+            .expect("Bob device can process messages");
 
-    let res = timeout(Duration::from_millis(300), bob_recv.recv())
-        .await
-        .expect("Bob receives message in time")
-        .expect("receiver works");
-    let bob_msg = String::from_utf8_lossy(res.content_bytes());
-    let res = timeout(Duration::from_millis(300), bob_device_recv.recv())
-        .await
-        .expect("Bob receives message in time")
-        .expect("receiver works");
-    let bob_device_msg = String::from_utf8_lossy(res.content_bytes());
+        let res = bob_recv.recv().await.expect("receiver works");
+        let bob_msg = String::from_utf8_lossy(res.content_bytes());
 
-    assert!(matches!(status, MessageStatus::Ok));
-    assert!(bob_msg == "Hello bob!");
-    assert!(bob_device_msg == "Hello bob!");
+        let res = bob_device_recv.recv().await.expect("receiver works");
+        let bob_device_msg = String::from_utf8_lossy(res.content_bytes());
+
+        assert!(matches!(status, MessageStatus::Ok));
+        assert!(bob_msg == "Hello bob!");
+        assert!(bob_device_msg == "Hello bob!");
+    })
+    .await
+    .expect("Test took to long to complete")
 }
 
 #[tokio::test]
 async fn alice_send_to_bob_needs_sync() {
-    let address = "127.0.0.1:9181";
-    let mut server = TestServer::start(address).await;
-    server
-        .started_rx()
-        .await
-        .expect("Should be able to start server");
+    timeout(Duration::from_secs(TIMEOUT_SECS), async {
+        let address = "127.0.0.1:9181";
+        let mut server = TestServer::start(address).await;
+        server
+            .started_rx()
+            .await
+            .expect("Should be able to start server");
 
-    let mut alice = client(address, "alice", "alice device").await;
-    let bob = client(address, "bob", "bob device").await;
+        let mut alice = client(address, "alice", "alice device").await;
+        let bob = client(address, "bob", "bob device").await;
 
-    let token = alice
-        .create_provision()
-        .await
-        .expect("bob can init provisioning");
-    let bob_id = bob.account_id().await.expect("Bob can get account id");
+        let token = alice
+            .create_provision()
+            .await
+            .expect("bob can init provisioning");
+        let bob_id = bob.account_id().await.expect("Bob can get account id");
 
-    let mut _alice_device = client_device(
-        address,
-        "bob_device",
-        alice.identity_key_pair().await.expect("can get id pair"),
-        token,
-    )
-    .await;
+        let mut _alice_device = client_device(
+            address,
+            "bob_device",
+            alice.identity_key_pair().await.expect("can get id pair"),
+            token,
+        )
+        .await;
 
-    alice
-        .fetch_prekeys(bob_id, None)
-        .await
-        .expect("Can fetch bob keys");
-    let status = alice
-        .send_message(bob_id, "Hello bob!")
-        .await
-        .expect("Alice can send message");
+        alice
+            .fetch_prekeys(bob_id, None)
+            .await
+            .expect("Can fetch bob keys");
+        let status = alice
+            .send_message(bob_id, "Hello bob!")
+            .await
+            .expect("Alice can send message");
 
-    assert!(matches!(status, MessageStatus::NeedsSync))
+        assert!(matches!(status, MessageStatus::NeedsSync))
+    })
+    .await
+    .expect("Test took to long to complete")
 }


### PR DESCRIPTION
all tests in message e2e have been wrapped in timeout, instead of timeout on single futures.  