### PR TITLE
Inspect error where we map_err(|_|...)

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1,7 +1,7 @@
 use bon::bon;
 use libsignal_core::ProtocolAddress;
 use libsignal_protocol::{process_prekey_bundle, IdentityKeyPair, IdentityKeyStore};
-use log::error;
+use log::{debug, error};
 use rand::rngs::OsRng;
 use sam_common::{
     address::RegistrationId,
@@ -538,8 +538,7 @@ impl<T: StoreType, U: ApiClient, V: SamProtocolClient> Client<T, U, V> {
                 .contact_store
                 .add_device(account_id, device_id.into())
                 .await?;
-            let libsignal_bundle = into_libsignal_bundle(bundle, prekey_bundles.identity_key)
-                .map_err(|_| ClientError::FailedToConvertPreKeyBundle)?;
+            let libsignal_bundle = into_libsignal_bundle(bundle, prekey_bundles.identity_key)?;
             process_prekey_bundle(
                 &ProtocolAddress::new(account_id.to_string(), device_id.into()),
                 &mut self.store.session_store,
@@ -549,6 +548,7 @@ impl<T: StoreType, U: ApiClient, V: SamProtocolClient> Client<T, U, V> {
                 &mut OsRng,
             )
             .await
+            .inspect_err(|e| debug!("{e}"))
             .map_err(|_| ClientError::FailedToProcessPrekeyBundle)?;
         }
 

--- a/client/src/encryption/encrypt.rs
+++ b/client/src/encryption/encrypt.rs
@@ -5,6 +5,7 @@ use libsignal_protocol::{
     message_decrypt, message_encrypt, CiphertextMessage, PlaintextContent, PreKeySignalMessage,
     SenderKeyMessage, SignalMessage,
 };
+use log::debug;
 use rand::rngs::OsRng;
 use sam_common::{
     sam_message::{ClientEnvelope, SamMessage, SamMessageType, ServerEnvelope},
@@ -112,6 +113,7 @@ pub async fn decrypt(
     };
 
     let source = AccountId::try_from(envelope.source_account_id)
+        .inspect_err(|e| debug!("{e}"))
         .map_err(|_| ClientError::InvalidAccountId("Could not parse bytes".to_owned()))?;
 
     let bytes = message_decrypt(

--- a/client/src/net/http_client.rs
+++ b/client/src/net/http_client.rs
@@ -3,6 +3,7 @@ use super::{
     ApiClientError,
 };
 use async_trait::async_trait;
+use log::debug;
 use reqwest::{Client as ReqwestClient, ClientBuilder, Method, Request, Response, Url};
 use rustls::ClientConfig;
 use sam_common::{
@@ -44,6 +45,7 @@ impl ApiClientConfig for HttpClientConfig {
             http_client: self
                 .client_builder
                 .build()
+                .inspect_err(|e| debug!("{e}"))
                 .map_err(|_| ApiClientError::FailedToBuildApiClient)?,
             base_url: self.base_url,
         })
@@ -69,6 +71,7 @@ impl HttpClient {
             .http_client
             .execute(request)
             .await
+            .inspect_err(|e| debug!("{e}"))
             .map_err(|_| ApiClientError::CouldNotSendRequest)?;
         let status = response.status();
 
@@ -96,13 +99,16 @@ impl ApiClient for HttpClient {
         registration_request: RegistrationRequest,
     ) -> Result<RegistrationResponse, ApiClientError> {
         let url_str = format!("{}/api/v1/account", self.base_url);
-        let url = Url::parse(&url_str).map_err(|_| ApiClientError::CouldNotParseUrl(url_str))?;
+        let url = Url::parse(&url_str)
+            .inspect_err(|e| debug!("{e}"))
+            .map_err(|_| ApiClientError::CouldNotParseUrl(url_str))?;
         let request = self
             .http_client
             .request(Method::POST, url)
             .json(&registration_request)
             .basic_auth(username, Some(password))
             .build()
+            .inspect_err(|e| debug!("{e}"))
             .map_err(|_| ApiClientError::CouldNotBuildRequest)?;
 
         let response = self.make_request(request).await?;
@@ -110,6 +116,7 @@ impl ApiClient for HttpClient {
         Ok(response
             .json()
             .await
+            .inspect_err(|e| debug!("{e}"))
             .map_err(|_| ApiClientError::CouldNotParseResponse)?)
     }
 
@@ -120,12 +127,15 @@ impl ApiClient for HttpClient {
         password: &str,
     ) -> Result<(), ApiClientError> {
         let url_str = format!("{}/api/v1/account", self.base_url);
-        let url = Url::parse(&url_str).map_err(|_| ApiClientError::CouldNotParseUrl(url_str))?;
+        let url = Url::parse(&url_str)
+            .inspect_err(|e| debug!("{e}"))
+            .map_err(|_| ApiClientError::CouldNotParseUrl(url_str))?;
         let request = self
             .http_client
             .request(Method::DELETE, url)
             .basic_auth(format!("{}.{}", account_id, device_id), Some(password))
             .build()
+            .inspect_err(|e| debug!("{e}"))
             .map_err(|_| ApiClientError::CouldNotBuildRequest)?;
 
         let _ = self.make_request(request).await?;
@@ -142,7 +152,9 @@ impl ApiClient for HttpClient {
         devices: Option<Vec<DeviceId>>,
     ) -> Result<PreKeyBundles, ApiClientError> {
         let url_str = format!("{}/api/v1/keys/{}", self.base_url, receiver_account_id);
-        let url = Url::parse(&url_str).map_err(|_| ApiClientError::CouldNotParseUrl(url_str))?;
+        let url = Url::parse(&url_str)
+            .inspect_err(|e| debug!("{e}"))
+            .map_err(|_| ApiClientError::CouldNotParseUrl(url_str))?;
 
         let request_builder = match devices {
             None => self
@@ -158,6 +170,7 @@ impl ApiClient for HttpClient {
 
         let request = request_builder
             .build()
+            .inspect_err(|e| debug!("{e}"))
             .map_err(|_| ApiClientError::CouldNotBuildRequest)?;
 
         let response = self.make_request(request).await?;
@@ -165,6 +178,7 @@ impl ApiClient for HttpClient {
         let prekey_bundles = response
             .json::<PreKeyBundles>()
             .await
+            .inspect_err(|e| debug!("{e}"))
             .map_err(|_| ApiClientError::CouldNotParseResponse)?;
 
         Ok(prekey_bundles)
@@ -178,7 +192,9 @@ impl ApiClient for HttpClient {
         bundle: PublishPreKeys,
     ) -> Result<(), ApiClientError> {
         let url_str = format!("{}/api/v1/keys", self.base_url);
-        let url = Url::parse(&url_str).map_err(|_| ApiClientError::CouldNotParseUrl(url_str))?;
+        let url = Url::parse(&url_str)
+            .inspect_err(|e| debug!("{e}"))
+            .map_err(|_| ApiClientError::CouldNotParseUrl(url_str))?;
 
         let request = self
             .http_client
@@ -186,6 +202,7 @@ impl ApiClient for HttpClient {
             .json(&bundle)
             .basic_auth(format!("{}.{}", account_id, device_id), Some(password))
             .build()
+            .inspect_err(|e| debug!("{e}"))
             .map_err(|_| ApiClientError::CouldNotBuildRequest)?;
 
         let _ = self.make_request(request).await?;
@@ -200,13 +217,16 @@ impl ApiClient for HttpClient {
         password: &str,
     ) -> Result<LinkDeviceToken, ApiClientError> {
         let url_str = format!("{}/api/v1/devices/provision", self.base_url);
-        let url = Url::parse(&url_str).map_err(|_| ApiClientError::CouldNotParseUrl(url_str))?;
+        let url = Url::parse(&url_str)
+            .inspect_err(|e| debug!("{e}"))
+            .map_err(|_| ApiClientError::CouldNotParseUrl(url_str))?;
 
         let request = self
             .http_client
             .request(Method::GET, url)
             .basic_auth(format!("{}.{}", account_id, device_id), Some(password))
             .build()
+            .inspect_err(|e| debug!("{e}"))
             .map_err(|_| ApiClientError::CouldNotBuildRequest)?;
 
         let response = self.make_request(request).await?;
@@ -214,6 +234,7 @@ impl ApiClient for HttpClient {
         let token = response
             .json::<LinkDeviceToken>()
             .await
+            .inspect_err(|e| debug!("{e}"))
             .map_err(|_| ApiClientError::CouldNotParseResponse)?;
 
         Ok(token)
@@ -226,7 +247,9 @@ impl ApiClient for HttpClient {
         request: LinkDeviceRequest,
     ) -> Result<LinkDeviceResponse, ApiClientError> {
         let url_str = format!("{}/api/v1/devices/link", self.base_url);
-        let url = Url::parse(&url_str).map_err(|_| ApiClientError::CouldNotParseUrl(url_str))?;
+        let url = Url::parse(&url_str)
+            .inspect_err(|e| debug!("{e}"))
+            .map_err(|_| ApiClientError::CouldNotParseUrl(url_str))?;
 
         let request = self
             .http_client
@@ -234,6 +257,7 @@ impl ApiClient for HttpClient {
             .json(&request)
             .basic_auth(username.to_owned(), Some(password))
             .build()
+            .inspect_err(|e| debug!("{e}"))
             .map_err(|_| ApiClientError::CouldNotBuildRequest)?;
 
         let response = self.make_request(request).await?;
@@ -241,6 +265,7 @@ impl ApiClient for HttpClient {
         let link_device_response = response
             .json::<LinkDeviceResponse>()
             .await
+            .inspect_err(|e| debug!("{e}"))
             .map_err(|_| ApiClientError::CouldNotParseResponse)?;
 
         Ok(link_device_response)
@@ -254,13 +279,16 @@ impl ApiClient for HttpClient {
         removed_device: DeviceId,
     ) -> Result<(), ApiClientError> {
         let url_str = format!("{}/api/v1/device/{}", self.base_url, removed_device);
-        let url = Url::parse(&url_str).map_err(|_| ApiClientError::CouldNotParseUrl(url_str))?;
+        let url = Url::parse(&url_str)
+            .inspect_err(|e| debug!("{e}"))
+            .map_err(|_| ApiClientError::CouldNotParseUrl(url_str))?;
 
         let request = self
             .http_client
             .request(Method::DELETE, url)
             .basic_auth(format!("{}.{}", account_id, device_id), Some(password))
             .build()
+            .inspect_err(|e| debug!("{e}"))
             .map_err(|_| ApiClientError::CouldNotBuildRequest)?;
 
         let _ = self.make_request(request).await?;
@@ -276,13 +304,16 @@ impl ApiClient for HttpClient {
         username: &str,
     ) -> Result<AccountId, ApiClientError> {
         let url_str = format!("{}/api/v1/account/{}", self.base_url, username);
-        let url = Url::parse(&url_str).map_err(|_| ApiClientError::CouldNotParseUrl(url_str))?;
+        let url = Url::parse(&url_str)
+            .inspect_err(|e| debug!("{e}"))
+            .map_err(|_| ApiClientError::CouldNotParseUrl(url_str))?;
 
         let request = self
             .http_client
             .request(Method::GET, url)
             .basic_auth(format!("{}.{}", account_id, device_id), Some(password))
             .build()
+            .inspect_err(|e| debug!("{e}"))
             .map_err(|_| ApiClientError::CouldNotBuildRequest)?;
 
         let response = self.make_request(request).await?;
@@ -290,6 +321,7 @@ impl ApiClient for HttpClient {
         let account_id = response
             .json::<AccountId>()
             .await
+            .inspect_err(|e| debug!("{e}"))
             .map_err(|_| ApiClientError::CouldNotParseResponse)?;
 
         Ok(account_id)

--- a/client/src/net/protocol/client.rs
+++ b/client/src/net/protocol/client.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use futures_util::{lock::Mutex, stream::SplitStream, StreamExt};
-use log::error;
+use log::{debug, error};
 use prost::Message as PMessage;
 use sam_common::{
     address::MessageId,
@@ -65,6 +65,7 @@ impl SamProtocolReceiver {
         message: ServerMessage,
     ) -> Result<Option<MessageId>, ProtocolError> {
         let id = MessageId::try_from(message.id.clone())
+            .inspect_err(|e| debug!("{e}"))
             .map_err(|_| ProtocolError::MalformedServerMessage)?;
 
         let content = match message.r#type() {
@@ -125,6 +126,7 @@ impl SamProtocolReceiver {
             Some(sender) => sender
                 .send(envelope)
                 .await
+                .inspect_err(|e| debug!("{e}"))
                 .map_err(|_| ProtocolError::WebSocketError(WebSocketError::Disconnected)),
             None => Err(ProtocolError::WebSocketError(WebSocketError::Disconnected)),
         }
@@ -137,6 +139,7 @@ impl SamProtocolReceiver {
         self.enqueue_status
             .send(status)
             .await
+            .inspect_err(|e| debug!("{e}"))
             .map_err(|_| ProtocolError::WebSocketError(WebSocketError::Disconnected))
             .map(|_| None)
     }
@@ -332,6 +335,7 @@ mod test {
     use std::time::Duration;
 
     use futures_util::{SinkExt, StreamExt};
+    use log::debug;
     use prost::{bytes::Bytes, Message as PMessage};
     use rstest::rstest;
     use sam_common::{
@@ -382,11 +386,14 @@ mod test {
         stream
             .send(Message::Binary(msg.encode_to_vec().into()))
             .await
+            .inspect_err(|e| debug!("{e}"))
             .map_err(|_| ())
     }
 
     fn decode_client_msg(bytes: Bytes) -> Result<ClientMessage, ()> {
-        ClientMessage::decode(bytes).map_err(|_| ())
+        ClientMessage::decode(bytes)
+            .inspect_err(|e| debug!("{e}"))
+            .map_err(|_| ())
     }
 
     fn client_env() -> ClientEnvelope {

--- a/client/src/net/protocol/mod.rs
+++ b/client/src/net/protocol/mod.rs
@@ -1,6 +1,7 @@
 use base64::{prelude::BASE64_STANDARD, Engine};
 use client::ProtocolClient;
 use error::ProtocolError;
+use log::debug;
 use rustls::ClientConfig;
 use sam_common::{AccountId, DeviceId};
 use std::sync::Arc;
@@ -60,6 +61,7 @@ impl ProtocolConfig for WebSocketProtocolClientConfig {
             .headers(vec![(
                 http::header::AUTHORIZATION,
                 http::HeaderValue::from_str(&basic)
+                    .inspect_err(|e| debug!("{e}"))
                     .map_err(|_| ProtocolError::InvalidCredentials)?,
             )])
             .build()

--- a/client/src/net/protocol/traits.rs
+++ b/client/src/net/protocol/traits.rs
@@ -1,5 +1,6 @@
 use super::error::ProtocolError;
 use async_trait::async_trait;
+use log::debug;
 use sam_common::{
     sam_message::{ClientEnvelope, DeviceList as ProtoDeviceList, ServerEnvelope},
     AccountId, DeviceId,
@@ -17,6 +18,7 @@ impl TryFrom<ProtoDeviceList> for DeviceList {
     fn try_from(value: ProtoDeviceList) -> Result<Self, Self::Error> {
         Ok(Self {
             account_id: AccountId::try_from(value.account_id)
+                .inspect_err(|e| debug!("{e}"))
                 .map_err(|_| ProtocolError::MalformedServerMessage)?,
             devices: value.device_ids.iter().map(|id| (*id).into()).collect(),
         })

--- a/client/src/net/protocol/websocket.rs
+++ b/client/src/net/protocol/websocket.rs
@@ -3,7 +3,7 @@ use futures_util::{
     stream::{SplitSink, SplitStream},
     SinkExt, StreamExt,
 };
-use log::error;
+use log::{debug, error};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
@@ -74,6 +74,7 @@ impl WebSocketClient {
             .url
             .clone()
             .into_client_request()
+            .inspect_err(|e| debug!("{e}"))
             .map_err(|_| WebSocketError::UrlError)?;
         let headers = req.headers_mut();
         for (name, value) in &self.config.headers {
@@ -124,6 +125,7 @@ impl WebSocketClient {
             Some(sender) => sender
                 .send(message)
                 .await
+                .inspect_err(|e| debug!("{e}"))
                 .map_err(|_| WebSocketError::Disconnected),
             None => Err(WebSocketError::Disconnected)?,
         };

--- a/client/src/storage/inmem/message.rs
+++ b/client/src/storage/inmem/message.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use log::debug;
 use tokio::sync::broadcast::{self, Receiver, Sender};
 
 use crate::{
@@ -26,6 +27,7 @@ impl MessageStore for InMemoryMessageStore {
         self.messages.push(envelope.clone());
         self.sender
             .send(envelope)
+            .inspect_err(|e| debug!("{e}"))
             .map_err(|_| ClientError::SendError)
             .map(|_| ())
     }

--- a/client/src/storage/sqlite/account.rs
+++ b/client/src/storage/sqlite/account.rs
@@ -2,6 +2,7 @@ use std::str::FromStr as _;
 
 use crate::{storage::AccountStore, ClientError};
 use async_trait::async_trait;
+use log::debug;
 use sam_common::address::AccountId;
 use sam_common::DeviceId;
 use sqlx::{Error as SqlxError, Pool, Sqlite};
@@ -43,9 +44,11 @@ impl AccountStore for SqliteAccountStore {
         )
         .fetch_one(&self.database)
         .await
+        .inspect_err(|e| debug!("{e}"))
         {
             Err(SqlxError::RowNotFound) => Err(ClientError::NoAccountId),
             Ok(rec) => AccountId::from_str(&rec.account_id)
+                .inspect_err(|e| debug!("{e}"))
                 .map_err(|_| ClientError::InvalidAccountId(rec.account_id)),
             Err(err) => Err(ClientError::Database(format!("{err}"))),
         }

--- a/client/src/storage/sqlite/message.rs
+++ b/client/src/storage/sqlite/message.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use log::debug;
 use sqlx::{Pool, Sqlite};
 use tokio::sync::broadcast::{self, Receiver, Sender};
 
@@ -44,6 +45,7 @@ impl MessageStore for SqliteMessageStore {
             Ok(()) => self
                 .sender
                 .send(envelope)
+                .inspect_err(|e| debug!("{e}"))
                 .map_err(|_| ClientError::SendError)
                 .map(|_| ()),
             Err(e) => Err(e),

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -22,6 +22,7 @@ uuid = { version = "1.11.0", features = ["serde", "v4"] }
 bon = "3.3.2"
 rand = "0.8.5"
 axum = "0.8.1"
+log = "0.4.25"
 
 [build-dependencies]
 prost-build = "0.13.4"

--- a/common/src/address.rs
+++ b/common/src/address.rs
@@ -8,8 +8,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::LibError;
 use derive_more::{Display, From, Into};
+use log::debug;
 use rand::Rng;
 use uuid::Uuid;
+
 macro_rules! define_uuid_type {
     ($name:ident) => {
         #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, From, Into, Serialize, Deserialize)]
@@ -45,7 +47,10 @@ macro_rules! define_uuid_type {
             type Error = LibError;
 
             fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
-                let bytes = value.try_into().map_err(|_| Self::Error::ConversionError)?;
+                let bytes = value
+                    .try_into()
+                    .inspect_err(|e| debug!("{:?}", e))
+                    .map_err(|_| Self::Error::ConversionError)?;
                 Ok(Self::parse_from_bytes(bytes))
             }
         }

--- a/server/src/auth/authenticated_user.rs
+++ b/server/src/auth/authenticated_user.rs
@@ -13,6 +13,7 @@ use axum::http::request::Parts;
 use axum_extra::headers::authorization::Basic;
 use axum_extra::headers::Authorization;
 use axum_extra::TypedHeader;
+use log::debug;
 use sam_common::address::AccountId;
 
 #[derive(Clone)]
@@ -42,16 +43,19 @@ impl<T: StateType> FromRequestParts<ServerState<T>> for AuthenticatedUser {
             let TypedHeader(basic) =
                 TypedHeader::<Authorization<Basic>>::from_request_parts(parts, &state)
                     .await
+                    .inspect_err(|e| debug!("{e}"))
                     .map_err(|_| AuthorizationError::AuthBasicParseError)?;
             (basic.username().to_string(), basic.password().to_string())
         };
         let (account_id, device_id) = userinfo
             .split_once(".")
             .ok_or(AuthorizationError::AuthBasicParseError)?;
-        let account_id =
-            AccountId::from_str(account_id).map_err(|_| AuthorizationError::AuthBasicParseError)?;
+        let account_id = AccountId::from_str(account_id)
+            .inspect_err(|e| debug!("{e}"))
+            .map_err(|_| AuthorizationError::AuthBasicParseError)?;
         let device_id = device_id
             .parse()
+            .inspect_err(|e| debug!("{e}"))
             .map_err(|_| AuthorizationError::AuthBasicParseError)?;
 
         let account = { state.accounts.get_account(account_id).await? };

--- a/server/src/auth/device.rs
+++ b/server/src/auth/device.rs
@@ -7,6 +7,7 @@ use base64::{
     Engine,
 };
 use hkdf::hmac::{Hmac, Mac};
+use log::debug;
 use sam_common::{address::AccountId, api::device::LinkDeviceToken, time_now_millis};
 use sha2::{Digest, Sha256};
 
@@ -31,6 +32,7 @@ pub fn verify_token(
     let expected_signature = create_signature(secret, claims);
     let signature = BASE64_URL_SAFE
         .decode(b64_signature)
+        .inspect_err(|e| debug!("{e}"))
         .map_err(|_| AuthorizationError::DeviceSignatureDecodeError)?;
 
     if signature != expected_signature {

--- a/server/src/auth/password.rs
+++ b/server/src/auth/password.rs
@@ -3,6 +3,7 @@ use argon2::{
     password_hash::{rand_core::OsRng, PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
     Argon2,
 };
+use log::debug;
 
 #[derive(Clone, bon::Builder, PartialEq, Eq)]
 pub struct Password {
@@ -16,15 +17,18 @@ impl Password {
         let salt = SaltString::generate(&mut OsRng);
         let hash = argon
             .hash_password(password.as_bytes(), &salt)
+            .inspect_err(|e| debug!("{e}"))
             .map_err(|_| AuthorizationError::PasswordHashError)?
             .to_string();
         Ok(Self { hash, salt })
     }
 
     pub fn verify(&self, password: String) -> Result<(), AuthorizationError> {
-        let pwd_hash =
-            PasswordHash::new(&self.hash).map_err(|_| AuthorizationError::PasswordHashError)?;
+        let pwd_hash = PasswordHash::new(&self.hash)
+            .inspect_err(|e| debug!("{e}"))
+            .map_err(|_| AuthorizationError::PasswordHashError)?;
         let res = Argon2::default().verify_password(password.as_bytes(), &pwd_hash);
-        res.map_err(|_| AuthorizationError::WrongPassword)
+        res.inspect_err(|e| debug!("{e}"))
+            .map_err(|_| AuthorizationError::WrongPassword)
     }
 }

--- a/server/src/managers/in_memory/message.rs
+++ b/server/src/managers/in_memory/message.rs
@@ -3,6 +3,7 @@ use std::{
     sync::Arc,
 };
 
+use log::debug;
 use sam_common::{
     address::{AccountId, DeviceAddress, DeviceId},
     sam_message::ServerEnvelope,
@@ -68,6 +69,7 @@ impl MessageManager for InMemoryMessageManager {
             sender
                 .send(envelope_id)
                 .await
+                .inspect_err(|e| debug!("{e}"))
                 .map_err(|_| MessageManagerError::MessageSubscriberSendError)?;
         }
         Ok(())
@@ -163,6 +165,7 @@ impl MessageManager for InMemoryMessageManager {
                             sender
                                 .send(id)
                                 .await
+                                .inspect_err(|e| debug!("{e}"))
                                 .map_err(|_| MessageManagerError::MessageSubscriberSendError)?;
                         }
                         Ok(())

--- a/server/src/protocol/websocket.rs
+++ b/server/src/protocol/websocket.rs
@@ -73,7 +73,9 @@ async fn websocket_message_receiver<T: StateType>(
                     "Received websocket message from user '{}'",
                     auth_user.account().username()
                 );
-                ClientMessage::decode(b).map_err(|_| WebSocketError::WebSocketDecodeError)
+                ClientMessage::decode(b)
+                    .inspect_err(|e| debug!("{e}"))
+                    .map_err(|_| WebSocketError::WebSocketDecodeError)
             }
             Message::Close(_) => Err(WebSocketError::WebSocketDisconnected),
             _ => continue,
@@ -106,6 +108,7 @@ async fn websocket_message_sender<T: StateType>(
                 sender
                     .send(Message::Binary(msg.encode_to_vec().into()))
                     .await
+                    .inspect_err(|e| debug!("{e}"))
                     .map_err(|_| WebSocketSessionError::from(WebSocketError::WebSocketSendError))
             }
             Err(WebSocketSessionError::WebSocket(WebSocketError::WebSocketDisconnected)) => Err(
@@ -118,6 +121,7 @@ async fn websocket_message_sender<T: StateType>(
                         reason: "Internal Server Error".into(),
                     })))
                     .await
+                    .inspect_err(|e| debug!("{e}"))
                     .map_err(|_| WebSocketError::WebSocketSendError);
                 match res {
                     Ok(_) => Err(err),


### PR DESCRIPTION
This pull request introduces extensive logging improvements across multiple files in the `client` module. The changes mainly involve adding `debug` logging for error inspection using the `inspect_err` method, which helps trace and debug errors more effectively.

### Logging Improvements:

* [`client/src/client.rs`](diffhunk://#diff-f74337de83c9232a0cc949a8d6d7390cf6e46b011b79383d9666ede90a902526L4-R4): Added `debug` logging for error inspection in various methods, including `into_libsignal_bundle`, `process_prekey_bundle`, and several API client methods. [[1]](diffhunk://#diff-f74337de83c9232a0cc949a8d6d7390cf6e46b011b79383d9666ede90a902526L4-R4) [[2]](diffhunk://#diff-f74337de83c9232a0cc949a8d6d7390cf6e46b011b79383d9666ede90a902526L541-R541) [[3]](diffhunk://#diff-f74337de83c9232a0cc949a8d6d7390cf6e46b011b79383d9666ede90a902526R551) [[4]](diffhunk://#diff-d04650eb6b899516d840883e5c345e1bb1e9e2c01eb042abcfad52882ac3125dR6) [[5]](diffhunk://#diff-d04650eb6b899516d840883e5c345e1bb1e9e2c01eb042abcfad52882ac3125dR48) [[6]](diffhunk://#diff-d04650eb6b899516d840883e5c345e1bb1e9e2c01eb042abcfad52882ac3125dR74) [[7]](diffhunk://#diff-d04650eb6b899516d840883e5c345e1bb1e9e2c01eb042abcfad52882ac3125dL99-R119) [[8]](diffhunk://#diff-d04650eb6b899516d840883e5c345e1bb1e9e2c01eb042abcfad52882ac3125dL123-R138) [[9]](diffhunk://#diff-d04650eb6b899516d840883e5c345e1bb1e9e2c01eb042abcfad52882ac3125dL145-R157) [[10]](diffhunk://#diff-d04650eb6b899516d840883e5c345e1bb1e9e2c01eb042abcfad52882ac3125dR173-R181) [[11]](diffhunk://#diff-d04650eb6b899516d840883e5c345e1bb1e9e2c01eb042abcfad52882ac3125dL181-R205) [[12]](diffhunk://#diff-d04650eb6b899516d840883e5c345e1bb1e9e2c01eb042abcfad52882ac3125dL203-R237) [[13]](diffhunk://#diff-d04650eb6b899516d840883e5c345e1bb1e9e2c01eb042abcfad52882ac3125dL229-R268) [[14]](diffhunk://#diff-d04650eb6b899516d840883e5c345e1bb1e9e2c01eb042abcfad52882ac3125dL257-R291) [[15]](diffhunk://#diff-d04650eb6b899516d840883e5c345e1bb1e9e2c01eb042abcfad52882ac3125dL279-R324)
* [`client/src/encryption/encrypt.rs`](diffhunk://#diff-5a65bb5f6b757d6ff4004068e8eb45f80e2f82daa9c1d34d861893849fb15f0bR8): Added `debug` logging for error inspection in the `decrypt` function. [[1]](diffhunk://#diff-5a65bb5f6b757d6ff4004068e8eb45f80e2f82daa9c1d34d861893849fb15f0bR8) [[2]](diffhunk://#diff-5a65bb5f6b757d6ff4004068e8eb45f80e2f82daa9c1d34d861893849fb15f0bR116)
* [`client/src/net/protocol/client.rs`](diffhunk://#diff-5df74dd69a0b3db744cb8c6144ad54b6e6658c0ca051adce76a54b45088d08deL4-R4): Added `debug` logging for error inspection in the `SamProtocolReceiver` implementation and test module. [[1]](diffhunk://#diff-5df74dd69a0b3db744cb8c6144ad54b6e6658c0ca051adce76a54b45088d08deL4-R4) [[2]](diffhunk://#diff-5df74dd69a0b3db744cb8c6144ad54b6e6658c0ca051adce76a54b45088d08deR68) [[3]](diffhunk://#diff-5df74dd69a0b3db744cb8c6144ad54b6e6658c0ca051adce76a54b45088d08deR129) [[4]](diffhunk://#diff-5df74dd69a0b3db744cb8c6144ad54b6e6658c0ca051adce76a54b45088d08deR142) [[5]](diffhunk://#diff-5df74dd69a0b3db744cb8c6144ad54b6e6658c0ca051adce76a54b45088d08deR338) [[6]](diffhunk://#diff-5df74dd69a0b3db744cb8c6144ad54b6e6658c0ca051adce76a54b45088d08deR389-R396)
* [`client/src/net/protocol/mod.rs`](diffhunk://#diff-1a027a800c45590d3547d54851234013d55a8e55038c74f342ec83a234859a6dR4): Added `debug` logging for error inspection in the `WebSocketProtocolClientConfig` implementation. [[1]](diffhunk://#diff-1a027a800c45590d3547d54851234013d55a8e55038c74f342ec83a234859a6dR4) [[2]](diffhunk://#diff-1a027a800c45590d3547d54851234013d55a8e55038c74f342ec83a234859a6dR64)
* [`client/src/net/protocol/traits.rs`](diffhunk://#diff-afabe7396832a81529ea624331590e1d1d2307426a06584fa549989fd7427e35R3): Added `debug` logging for error inspection in the `TryFrom<ProtoDeviceList>` implementation. [[1]](diffhunk://#diff-afabe7396832a81529ea624331590e1d1d2307426a06584fa549989fd7427e35R3) [[2]](diffhunk://#diff-afabe7396832a81529ea624331590e1d1d2307426a06584fa549989fd7427e35R21)
* [`client/src/net/protocol/websocket.rs`](diffhunk://#diff-a27801c4e8c0d79a1fde08444a2b3ac9203836330bdfdb923431832e063c5c9dL6-R6): Added `debug` logging for error inspection in the `WebSocketClient` implementation. [[1]](diffhunk://#diff-a27801c4e8c0d79a1fde08444a2b3ac9203836330bdfdb923431832e063c5c9dL6-R6) [[2]](diffhunk://#diff-a27801c4e8c0d79a1fde08444a2b3ac9203836330bdfdb923431832e063c5c9dR77) [[3]](diffhunk://#diff-a27801c4e8c0d79a1fde08444a2b3ac9203836330bdfdb923431832e063c5c9dR128)
* [`client/src/storage/inmem/message.rs`](diffhunk://#diff-db1297cbc1b557376a7605d53396fa5bfbc1d30a039a9cdcea3aaf4191cc7d36R2): Added `debug` logging for error inspection.