### PR TITLE
Fixed Client device trying to fetch its own keys and added argument parser

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "**/main.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ tokio-tungstenite = { version = "0.26.2" }
 reqwest = { version = "0.12.12" }
 serde = { version = "1.0.210" }
 serde_with = { version = "3.11.0" }
+clap = "4.5.32"
 
 # Dev dependencies
 rstest = "0.24.0"

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -93,6 +93,10 @@ impl<T: StoreType, U: ApiClient, V: SamProtocolClient> Client<T, U, V> {
             .set_device_id(response.device_id)
             .await?;
         store.account_store.set_password(password.clone()).await?;
+        store
+            .contact_store
+            .add_device(response.account_id, response.device_id)
+            .await?;
 
         let mut protocol_client = protocol_config
             .create(response.account_id, response.device_id, password.clone())
@@ -159,6 +163,10 @@ impl<T: StoreType, U: ApiClient, V: SamProtocolClient> Client<T, U, V> {
         store.account_store.set_account_id(account_id).await?;
         store.account_store.set_device_id(1.into()).await?;
         store.account_store.set_password(password).await?;
+        store
+            .contact_store
+            .add_device(response.account_id, 1.into())
+            .await?;
 
         let queue = protocol_client.connect().await?;
 

--- a/client/src/encryption/encrypt.rs
+++ b/client/src/encryption/encrypt.rs
@@ -13,7 +13,7 @@ use sam_common::{
 };
 
 use crate::{
-    storage::{ContactStore, Store, StoreType},
+    storage::{AccountStore, ContactStore, Store, StoreType},
     ClientError,
 };
 
@@ -45,12 +45,15 @@ pub async fn encrypt(
     let bytes = pad_message(&message.into());
 
     let mut recipient_addrs = HashMap::new();
+    let my_id = store.account_store.get_account_id().await?;
+    let my_device_id = store.account_store.get_device_id().await?;
 
     for recipient in recipients {
-        recipient_addrs.insert(
-            recipient,
-            store.contact_store.get_all_devices(recipient).await?,
-        );
+        let mut devices = store.contact_store.get_all_devices(recipient).await?;
+        if recipient == my_id {
+            devices.retain(|id| *id != my_device_id);
+        }
+        recipient_addrs.insert(recipient, devices);
     }
 
     let addr_len = recipient_addrs.values().map(|v| v.len()).sum();
@@ -162,7 +165,7 @@ mod test {
             key_generation::{
                 into_libsignal_bundle, KyberKeyGenerator, PreKeyGenerator, SignedPreKeyGenerator,
             },
-            ContactStore, Store, StoreConfig, StoreType,
+            AccountStore, ContactStore, Store, StoreConfig, StoreType,
         },
     };
 
@@ -248,7 +251,16 @@ mod test {
         let my_struct = MyStruct {
             string: "Hello, World!".to_owned(),
         };
-
+        alice_store
+            .account_store
+            .set_account_id(alice)
+            .await
+            .expect("Can add self account id");
+        alice_store
+            .account_store
+            .set_device_id(1.into())
+            .await
+            .expect("can add self device id");
         alice_store
             .contact_store
             .add_device(bob, 1.into())

--- a/client/src/net/protocol/mod.rs
+++ b/client/src/net/protocol/mod.rs
@@ -11,7 +11,7 @@ use websocket::WebSocketClientConfig;
 pub mod client;
 pub mod error;
 pub mod traits;
-mod websocket;
+pub mod websocket;
 
 pub use client::ProtocolClient;
 pub use traits::{DeviceList, MessageStatus, ProtocolConfig, SamProtocolClient};

--- a/e2e/tests/message.rs
+++ b/e2e/tests/message.rs
@@ -333,8 +333,12 @@ async fn test_alice_send_to_bob_and_self() {
         )
         .await;
 
+        let bob_expected = "Hello bob!";
+        let res = alice.send_message(bob_id, bob_expected).await;
+        assert!(matches!(res, Err(ClientError::MissingDevices)));
+
         alice
-            .send_message(bob_id, "Hello bob!")
+            .send_message(bob_id, bob_expected)
             .await
             .expect("Alice can send message");
 
@@ -348,7 +352,7 @@ async fn test_alice_send_to_bob_and_self() {
         let res = alice_recv.recv().await.expect("receiver works");
         let bob_msg = String::from_utf8_lossy(res.content_bytes());
 
-        assert!(bob_msg == "Hello bob!")
+        assert!(bob_msg == bob_expected)
     })
     .await
     .expect("Test took to long to complete")

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -14,6 +14,7 @@ sha2 = { workspace = true }
 rand = { workspace = true }
 base64 = { workspace = true }
 argon2 = { workspace = true }
+clap = { workspace = true }
 libsignal-protocol = { workspace = true }
 derive_more = { workspace = true, features = ["display", "error", "from"] }
 sam-common = { workspace = true }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,40 +1,89 @@
+use clap::{Arg, Command};
+use log::info;
 use rustls_pemfile::{certs, private_key};
 use sam_server::{start_server, state::ServerState, ServerConfig};
-use std::env;
 use std::fs::File;
 use std::io::BufReader;
 use std::sync::Arc;
 
 #[tokio::main]
 pub async fn main() {
-    let _ = rustls::crypto::ring::default_provider().install_default();
     env_logger::init();
-    let args: Vec<String> = env::args().collect();
+    let matches = Command::new("sam_server")
+        .arg(
+            Arg::new("cert")
+                .short('c')
+                .long("certificate")
+                .required(false)
+                .help(".crt file")
+                .requires("key"),
+        )
+        .arg(
+            Arg::new("key")
+                .short('k')
+                .long("key")
+                .required(false)
+                .help(".key file")
+                .requires("cert"),
+        )
+        .arg(
+            Arg::new("ip")
+                .short('i')
+                .long("ip")
+                .required(false)
+                .help("IP to run server on")
+                .default_value("127.0.0.1"),
+        )
+        .arg(
+            Arg::new("port")
+                .short('p')
+                .long("port")
+                .required(false)
+                .help("Port to run server on")
+                .default_value("8080"),
+        )
+        .get_matches();
+
+    let tls = if let (Some(cert), Some(key)) = (
+        matches.get_one::<String>("cert"),
+        matches.get_one::<String>("key"),
+    ) {
+        info!("Using TLS");
+        info!("Cerificate: '{}'", cert);
+        info!("Key: '{}'", key);
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let cert_file = File::open(cert).expect("Failed to open cert file");
+        let mut cert_reader = BufReader::new(cert_file);
+        let cert_chain = certs(&mut cert_reader)
+            .map(|cert| cert.expect("Certificate should be there"))
+            .collect::<Vec<_>>();
+
+        let key_file = File::open(key).expect("Failed to open key file");
+        let mut key_reader = BufReader::new(key_file);
+        let key = private_key(&mut key_reader)
+            .expect("Should find key")
+            .expect("Key should be there");
+
+        let server_config = rustls::ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(cert_chain, key)
+            .expect("Failed to create rustls::ServerConfig");
+        Some(Arc::new(server_config))
+    } else {
+        None
+    };
+
+    let ip = matches.get_one::<String>("ip").expect("IP has default");
+    let port = matches.get_one::<String>("port").expect("Port has default");
+
+    let addr = format!("{}:{}", ip, port);
+
     let state = ServerState::in_memory("test".to_string(), 600, 10);
-
-    let cert_file = File::open(&args[1]).expect("Failed to open cert file");
-    let mut cert_reader = BufReader::new(cert_file);
-    let cert_chain = certs(&mut cert_reader)
-        .map(|cert| cert.expect("Certificate should be there"))
-        .collect::<Vec<_>>();
-
-    let key_file = File::open(&args[2]).expect("Failed to open key file");
-    let mut key_reader = BufReader::new(key_file);
-    let key = private_key(&mut key_reader)
-        .expect("Should find key")
-        .expect("Key should be there");
-
-    let server_config = rustls::ServerConfig::builder()
-        .with_no_client_auth()
-        .with_single_cert(cert_chain, key)
-        .expect("Failed to create rustls::ServerConfig");
 
     let config = ServerConfig {
         state,
-        addr: "127.0.0.1:8080"
-            .parse()
-            .expect("Unable to parse socket address"),
-        tls_config: Some(Arc::new(server_config)),
+        addr: addr.parse().expect("Unable to parse socket address"),
+        tls_config: tls,
     };
     start_server(config).await.unwrap();
 }

--- a/server/src/protocol/message.rs
+++ b/server/src/protocol/message.rs
@@ -71,7 +71,7 @@ async fn handle_client_envelope<T: StateType>(
     message_id: MessageId,
     envelope: ClientEnvelope,
 ) -> Result<ServerMessage, ServerError> {
-    let dest_acc_ids = envelope
+    let mut dest_acc_ids = envelope
         .recipients()
         .ok_or(ServerError::EnvelopeMalformed)?;
 
@@ -85,6 +85,10 @@ async fn handle_client_envelope<T: StateType>(
             .id(message_id.into())
             .r#type(ServerMessageType::EmptyMessage.into())
             .build());
+    }
+
+    if !dest_acc_ids.contains_key(&sender_account_id) {
+        dest_acc_ids.insert(sender_account_id, Vec::new());
     }
 
     for (recipient, devices) in dest_acc_ids {

--- a/server/src/protocol/message.rs
+++ b/server/src/protocol/message.rs
@@ -87,7 +87,9 @@ async fn handle_client_envelope<T: StateType>(
             .build());
     }
 
-    dest_acc_ids.entry(sender_account_id).or_insert_with(Vec::new);
+    dest_acc_ids
+        .entry(sender_account_id)
+        .or_insert_with(Vec::new);
 
     for (recipient, devices) in dest_acc_ids {
         let mut all_devices = state.devices.get_devices(recipient).await?;

--- a/server/src/protocol/message.rs
+++ b/server/src/protocol/message.rs
@@ -87,9 +87,7 @@ async fn handle_client_envelope<T: StateType>(
             .build());
     }
 
-    if !dest_acc_ids.contains_key(&sender_account_id) {
-        dest_acc_ids.insert(sender_account_id, Vec::new());
-    }
+    dest_acc_ids.entry(sender_account_id).or_insert_with(Vec::new);
 
     for (recipient, devices) in dest_acc_ids {
         let mut all_devices = state.devices.get_devices(recipient).await?;


### PR DESCRIPTION
- Server now adds the senders account id and empty vector to recipients when client sends message and it has not included it self, so it responds with missing devices, when the client has not included it self in its message.
- `encrypt` now removes current device from encryption
-  `net::protocol::websocket` module is now public
- added arguments for cert, key and address the server needs to be run on

closes #87 
closes #97 