### PR TITLE
Refactored errors on Client

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -184,11 +184,15 @@ impl<T: ClientType> Client<T> {
     }
 
     pub async fn account_id(&self) -> Result<AccountId, ClientError> {
-        self.store.account_store.get_account_id().await
+        Ok(self.store.account_store.get_account_id().await?)
     }
 
     pub async fn device_id(&self) -> Result<DeviceId, ClientError> {
-        self.store.account_store.get_device_id().await
+        Ok(self.store.account_store.get_device_id().await?)
+    }
+
+    pub async fn password(&self) -> Result<String, ClientError> {
+        Ok(self.store.account_store.get_password().await?)
     }
 
     pub async fn identity_key_pair(&self) -> Result<IdentityKeyPair, ClientError> {
@@ -204,7 +208,7 @@ impl<T: ClientType> Client<T> {
     pub async fn delete_account(self) -> Result<(), (Self, ClientError)> {
         let account_id = self.account_id().await;
         let device_id = self.device_id().await;
-        let password = self.store.account_store.get_password().await;
+        let password = self.password().await;
 
         let Ok(account_id) = account_id else {
             return Err((self, account_id.unwrap_err()));
@@ -237,7 +241,7 @@ impl<T: ClientType> Client<T> {
     pub async fn delete_device(self) -> Result<(), (Self, ClientError)> {
         let account_id = self.account_id().await;
         let device_id = self.device_id().await;
-        let password = self.store.account_store.get_password().await;
+        let password = self.password().await;
 
         let Ok(account_id) = account_id else {
             return Err((self, account_id.unwrap_err()));
@@ -270,7 +274,7 @@ impl<T: ClientType> Client<T> {
             .delete_device(
                 self.account_id().await?,
                 self.device_id().await?,
-                &self.store.account_store.get_password().await?,
+                &self.password().await?,
                 device_id,
             )
             .await?;
@@ -284,7 +288,7 @@ impl<T: ClientType> Client<T> {
             .get_user_account_id(
                 self.account_id().await?,
                 self.device_id().await?,
-                self.store.account_store.get_password().await?.as_str(),
+                &self.password().await?,
                 username,
             )
             .await?;
@@ -371,7 +375,7 @@ impl<T: ClientType> Client<T> {
             .provision_device(
                 self.account_id().await?,
                 self.device_id().await?,
-                &self.store.account_store.get_password().await?,
+                &self.password().await?,
             )
             .await?)
     }

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -191,7 +191,7 @@ impl<T: ClientType> Client<T> {
         Ok(self.store.account_store.get_device_id().await?)
     }
 
-    pub async fn password(&self) -> Result<String, ClientError> {
+    async fn password(&self) -> Result<String, ClientError> {
         Ok(self.store.account_store.get_password().await?)
     }
 

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -341,12 +341,12 @@ impl<T: ClientType> Client<T> {
 
     /// Recieve and decrypt messages. Block until at least one message is received.
     pub async fn process_messages_blocking(&mut self) -> Result<(), ClientError> {
-        process_messages(&mut self.store, &mut self.envelope_queue, true).await
+        Ok(process_messages(&mut self.store, &mut self.envelope_queue, true).await?)
     }
 
     /// Recieve and decrypt messages.
     pub async fn process_messages(&mut self) -> Result<(), ClientError> {
-        process_messages(&mut self.store, &mut self.envelope_queue, false).await
+        Ok(process_messages(&mut self.store, &mut self.envelope_queue, false).await?)
     }
 
     /// Publish new prekeys.
@@ -357,7 +357,7 @@ impl<T: ClientType> Client<T> {
         #[builder(default = false)] new_signed_prekey: bool,
         #[builder(default = false)] new_last_resort: bool,
     ) -> Result<(), ClientError> {
-        publish_prekeys(
+        Ok(publish_prekeys(
             &mut self.store,
             &self.api_client,
             onetime_prekeys,
@@ -365,7 +365,7 @@ impl<T: ClientType> Client<T> {
             new_last_resort,
             &mut self.rng,
         )
-        .await
+        .await?)
     }
 
     /// Create a provisioning token for linking a new device to your account.

--- a/client/src/encryption/encrypt.rs
+++ b/client/src/encryption/encrypt.rs
@@ -12,13 +12,11 @@ use sam_common::{
     AccountId,
 };
 
-use crate::{
-    storage::{AccountStore, ContactStore, Store, StoreType},
-    ClientError,
-};
+use crate::storage::{AccountStore, ContactStore, Store, StoreType};
 
 use super::{
     envelope::DecryptedEnvelope,
+    error::EncryptionError,
     padding::{pad_message, unpad_message},
 };
 
@@ -41,7 +39,7 @@ pub async fn encrypt(
     message: impl Into<Vec<u8>>,
     recipients: Vec<AccountId>,
     store: &mut Store<impl StoreType>,
-) -> Result<ClientEnvelope, ClientError> {
+) -> Result<ClientEnvelope, EncryptionError> {
     let bytes = pad_message(&message.into());
 
     let mut recipient_addrs = HashMap::new();
@@ -102,7 +100,7 @@ pub async fn encrypt(
 pub async fn decrypt(
     envelope: ServerEnvelope,
     store: &mut Store<impl StoreType>,
-) -> Result<DecryptedEnvelope, ClientError> {
+) -> Result<DecryptedEnvelope, EncryptionError> {
     let message = match envelope.r#type() {
         SamMessageType::SignalMessage => {
             CiphertextMessage::SignalMessage(SignalMessage::try_from(envelope.content.as_slice())?)
@@ -120,7 +118,7 @@ pub async fn decrypt(
 
     let source = AccountId::try_from(envelope.source_account_id)
         .inspect_err(|e| debug!("{e}"))
-        .map_err(|_| ClientError::InvalidAccountId("Could not parse bytes".to_owned()))?;
+        .map_err(|_| EncryptionError::InvalidAccountId("Could not parse bytes".to_owned()))?;
 
     let bytes = unpad_message(
         &message_decrypt(
@@ -135,7 +133,7 @@ pub async fn decrypt(
         )
         .await?,
     )
-    .ok_or(ClientError::FailedToUnpadMessage)?;
+    .ok_or(EncryptionError::FailedToUnpadMessage)?;
 
     Ok(DecryptedEnvelope::builder()
         .source_account_id(source)

--- a/client/src/encryption/encrypt.rs
+++ b/client/src/encryption/encrypt.rs
@@ -157,14 +157,12 @@ mod test {
     };
 
     use crate::{
-        encryption::encrypt::{decrypt, encrypt},
-        storage::{
+        encryption::encrypt::{decrypt, encrypt}, logic::into_libsignal_bundle, storage::{
             inmem::InMemoryStoreConfig,
-            key_generation::{
-                into_libsignal_bundle, KyberKeyGenerator, PreKeyGenerator, SignedPreKeyGenerator,
+            key_generation::{KyberKeyGenerator, PreKeyGenerator, SignedPreKeyGenerator,
             },
             AccountStore, ContactStore, Store, StoreConfig, StoreType,
-        },
+        }
     };
 
     pub async fn create_pre_key_bundle<R: Rng + CryptoRng>(

--- a/client/src/encryption/encrypt.rs
+++ b/client/src/encryption/encrypt.rs
@@ -157,12 +157,13 @@ mod test {
     };
 
     use crate::{
-        encryption::encrypt::{decrypt, encrypt}, logic::into_libsignal_bundle, storage::{
+        encryption::encrypt::{decrypt, encrypt},
+        logic::into_libsignal_bundle,
+        storage::{
             inmem::InMemoryStoreConfig,
-            key_generation::{KyberKeyGenerator, PreKeyGenerator, SignedPreKeyGenerator,
-            },
+            key_generation::{KyberKeyGenerator, PreKeyGenerator, SignedPreKeyGenerator},
             AccountStore, ContactStore, Store, StoreConfig, StoreType,
-        }
+        },
     };
 
     pub async fn create_pre_key_bundle<R: Rng + CryptoRng>(

--- a/client/src/encryption/error.rs
+++ b/client/src/encryption/error.rs
@@ -1,12 +1,11 @@
 use derive_more::derive::{Display, Error, From};
 use libsignal_protocol::SignalProtocolError;
 
-use crate::storage::error::{AccountStoreError, ContactStoreError, StoreCreationError};
+use crate::storage::error::{AccountStoreError, ContactStoreError};
 
 #[derive(Debug, Display, Error, From)]
 pub enum EncryptionError {
     FailedToUnpadMessage,
-    Store(StoreCreationError),
     SignalProtocol(SignalProtocolError),
     #[display("Failed to parse an invalid AccountId: {_0}")]
     #[error(ignore)]

--- a/client/src/encryption/error.rs
+++ b/client/src/encryption/error.rs
@@ -1,0 +1,14 @@
+use derive_more::derive::{Display, Error, From};
+use libsignal_protocol::SignalProtocolError;
+
+use crate::storage::error::StoreError;
+
+#[derive(Debug, Display, Error, From)]
+pub enum EncryptionError {
+    FailedToUnpadMessage,
+    Store(StoreError),
+    SignalProtocol(SignalProtocolError),
+    #[display("Failed to parse an invalid AccountId: {_0}")]
+    #[error(ignore)]
+    InvalidAccountId(String),
+}

--- a/client/src/encryption/error.rs
+++ b/client/src/encryption/error.rs
@@ -8,8 +8,7 @@ pub enum EncryptionError {
     FailedToUnpadMessage,
     SignalProtocol(SignalProtocolError),
     #[display("Failed to parse an invalid AccountId: {_0}")]
-    #[error(ignore)]
-    InvalidAccountId(String),
+    InvalidAccountId(#[error(not(source))] String),
     AccountStore(AccountStoreError),
     ContactStore(ContactStoreError),
 }

--- a/client/src/encryption/error.rs
+++ b/client/src/encryption/error.rs
@@ -1,14 +1,16 @@
 use derive_more::derive::{Display, Error, From};
 use libsignal_protocol::SignalProtocolError;
 
-use crate::storage::error::StoreError;
+use crate::storage::error::{AccountStoreError, ContactStoreError, StoreCreationError};
 
 #[derive(Debug, Display, Error, From)]
 pub enum EncryptionError {
     FailedToUnpadMessage,
-    Store(StoreError),
+    Store(StoreCreationError),
     SignalProtocol(SignalProtocolError),
     #[display("Failed to parse an invalid AccountId: {_0}")]
     #[error(ignore)]
     InvalidAccountId(String),
+    AccountStore(AccountStoreError),
+    ContactStore(ContactStoreError),
 }

--- a/client/src/encryption/mod.rs
+++ b/client/src/encryption/mod.rs
@@ -1,5 +1,6 @@
 pub mod encrypt;
 pub mod envelope;
+pub mod error;
 pub mod padding;
 pub mod password;
 

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -11,7 +11,7 @@ pub enum ClientError {
     SignalProtocol(SignalProtocolError),
     Api(ApiClientError),
     Protocol(ProtocolError),
-    Store(StoreCreationError),
+    StoreCreation(StoreCreationError),
     AccountStore(AccountStoreError),
     Logic(LogicError),
     Encryption(EncryptionError),

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -4,6 +4,7 @@ use libsignal_protocol::SignalProtocolError;
 use sam_common::LibError;
 
 use crate::net::{protocol::error::ProtocolError, ApiClientError};
+use crate::storage::error::StoreError;
 
 #[derive(Debug, Display, Error, From)]
 pub enum ClientError {
@@ -12,19 +13,12 @@ pub enum ClientError {
     InvalidAccountId(String),
     SignalProtocol(SignalProtocolError),
     #[from(ignore)]
-    Database(#[error(not(source))] String),
     Lib(LibError),
     Curve(CurveError),
     Api(ApiClientError),
     Protocol(ProtocolError),
+    Store(StoreError),
     MissingDevices,
-    NoAccountId,
-    NoPassword,
-    NoUsername,
-    SendError,
-    NoDeviceId,
-    NoContact,
-    FailedToConvertPreKeyBundle,
     FailedToProcessPrekeyBundle,
     FailedToUnpadMessage,
 }

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -1,24 +1,17 @@
 use derive_more::derive::{Display, Error, From};
-use libsignal_core::curve::CurveError;
 use libsignal_protocol::SignalProtocolError;
-use sam_common::LibError;
 
+use crate::encryption::error::EncryptionError;
+use crate::logic::LogicError;
 use crate::net::{protocol::error::ProtocolError, ApiClientError};
 use crate::storage::error::StoreError;
 
 #[derive(Debug, Display, Error, From)]
 pub enum ClientError {
-    #[display("Failed to parse an invalid AccountId: {_0}")]
-    #[error(ignore)]
-    InvalidAccountId(String),
     SignalProtocol(SignalProtocolError),
-    #[from(ignore)]
-    Lib(LibError),
-    Curve(CurveError),
     Api(ApiClientError),
     Protocol(ProtocolError),
     Store(StoreError),
-    MissingDevices,
-    FailedToProcessPrekeyBundle,
-    FailedToUnpadMessage,
+    Logic(LogicError),
+    Encryption(EncryptionError),
 }

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -4,14 +4,15 @@ use libsignal_protocol::SignalProtocolError;
 use crate::encryption::error::EncryptionError;
 use crate::logic::LogicError;
 use crate::net::{protocol::error::ProtocolError, ApiClientError};
-use crate::storage::error::StoreError;
+use crate::storage::error::{AccountStoreError, StoreCreationError};
 
 #[derive(Debug, Display, Error, From)]
 pub enum ClientError {
     SignalProtocol(SignalProtocolError),
     Api(ApiClientError),
     Protocol(ProtocolError),
-    Store(StoreError),
+    Store(StoreCreationError),
+    AccountStore(AccountStoreError),
     Logic(LogicError),
     Encryption(EncryptionError),
 }

--- a/client/src/logic/account.rs
+++ b/client/src/logic/account.rs
@@ -49,5 +49,9 @@ pub async fn register_account<T: StoreType, R: Rng + CryptoRng>(
     store.account_store.set_account_id(account_id).await?;
     store.account_store.set_device_id(device_id).await?;
     store.account_store.set_password(password).await?;
-    store.contact_store.add_device(account_id, device_id).await
+    store
+        .contact_store
+        .add_device(account_id, device_id)
+        .await?;
+    Ok(())
 }

--- a/client/src/logic/account.rs
+++ b/client/src/logic/account.rs
@@ -8,8 +8,9 @@ use crate::{
     storage::{
         key_generation::create_registration_pre_keys, AccountStore, ContactStore, Store, StoreType,
     },
-    ClientError,
 };
+
+use super::LogicError;
 
 pub async fn register_account<T: StoreType, R: Rng + CryptoRng>(
     api_client: &impl ApiClient,
@@ -19,7 +20,7 @@ pub async fn register_account<T: StoreType, R: Rng + CryptoRng>(
     password_length: usize,
     upload_prekey_count: usize,
     mut rng: &mut R,
-) -> Result<(), ClientError> {
+) -> Result<(), LogicError> {
     let password = generate_password(password_length, &mut rng);
     let id_pair = store.identity_key_store.get_identity_key_pair().await?;
     let key_bundle =

--- a/client/src/logic/device.rs
+++ b/client/src/logic/device.rs
@@ -8,8 +8,9 @@ use crate::{
     storage::{
         key_generation::create_registration_pre_keys, AccountStore, ContactStore, Store, StoreType,
     },
-    ClientError,
 };
+
+use super::LogicError;
 
 pub async fn provision_device<T: StoreType, R: Rng + CryptoRng>(
     api_client: &impl ApiClient,
@@ -19,7 +20,7 @@ pub async fn provision_device<T: StoreType, R: Rng + CryptoRng>(
     upload_prekey_count: usize,
     password_length: usize,
     mut rng: &mut R,
-) -> Result<(), ClientError> {
+) -> Result<(), LogicError> {
     let id_key_pair = store.identity_key_store.get_identity_key_pair().await?;
     let key_bundle =
         create_registration_pre_keys(store, upload_prekey_count, id_key_pair, &mut rng).await?;

--- a/client/src/logic/device.rs
+++ b/client/src/logic/device.rs
@@ -50,5 +50,6 @@ pub async fn provision_device<T: StoreType, R: Rng + CryptoRng>(
     store
         .contact_store
         .add_device(response.account_id, response.device_id)
-        .await
+        .await?;
+    Ok(())
 }

--- a/client/src/logic/error.rs
+++ b/client/src/logic/error.rs
@@ -2,15 +2,25 @@ use derive_more::derive::{Display, Error, From};
 use libsignal_core::curve::CurveError;
 use libsignal_protocol::SignalProtocolError;
 
-use crate::{encryption::error::EncryptionError, net::ApiClientError, storage::error::StoreError};
+use crate::{
+    encryption::error::EncryptionError,
+    net::ApiClientError,
+    storage::error::{
+        AccountStoreError, ContactStoreError, KeyStoreError, MessageStoreError, StoreCreationError,
+    },
+};
 
 #[derive(Debug, Display, Error, From)]
 pub enum LogicError {
     MissingDevices,
     FailedToProcessPrekeyBundle,
-    Store(StoreError),
+    Store(StoreCreationError),
     Api(ApiClientError),
     Curve(CurveError),
     SignalProtocol(SignalProtocolError),
     Encryption(EncryptionError),
+    AccountStore(AccountStoreError),
+    ContactStore(ContactStoreError),
+    MessageStore(MessageStoreError),
+    KeyStore(KeyStoreError),
 }

--- a/client/src/logic/error.rs
+++ b/client/src/logic/error.rs
@@ -1,0 +1,16 @@
+use derive_more::derive::{Display, Error, From};
+use libsignal_core::curve::CurveError;
+use libsignal_protocol::SignalProtocolError;
+
+use crate::{encryption::error::EncryptionError, net::ApiClientError, storage::error::StoreError};
+
+#[derive(Debug, Display, Error, From)]
+pub enum LogicError {
+    MissingDevices,
+    FailedToProcessPrekeyBundle,
+    Store(StoreError),
+    Api(ApiClientError),
+    Curve(CurveError),
+    SignalProtocol(SignalProtocolError),
+    Encryption(EncryptionError),
+}

--- a/client/src/logic/error.rs
+++ b/client/src/logic/error.rs
@@ -5,16 +5,13 @@ use libsignal_protocol::SignalProtocolError;
 use crate::{
     encryption::error::EncryptionError,
     net::ApiClientError,
-    storage::error::{
-        AccountStoreError, ContactStoreError, KeyStoreError, MessageStoreError, StoreCreationError,
-    },
+    storage::error::{AccountStoreError, ContactStoreError, KeyStoreError, MessageStoreError},
 };
 
 #[derive(Debug, Display, Error, From)]
 pub enum LogicError {
     MissingDevices,
     FailedToProcessPrekeyBundle,
-    Store(StoreCreationError),
     Api(ApiClientError),
     Curve(CurveError),
     SignalProtocol(SignalProtocolError),

--- a/client/src/logic/key.rs
+++ b/client/src/logic/key.rs
@@ -15,8 +15,9 @@ use crate::{
         },
         AccountStore, ContactStore, Store, StoreType,
     },
-    ClientError,
 };
+
+use super::LogicError;
 
 pub async fn fetch_prekeys<T: StoreType, R: Rng + CryptoRng>(
     store: &mut Store<T>,
@@ -24,7 +25,7 @@ pub async fn fetch_prekeys<T: StoreType, R: Rng + CryptoRng>(
     account_id: AccountId,
     devices: Option<Vec<DeviceId>>,
     mut rng: &mut R,
-) -> Result<(), ClientError> {
+) -> Result<(), LogicError> {
     let prekey_bundles = api_client
         .get_pre_key_bundles(
             store.account_store.get_account_id().await?,
@@ -52,7 +53,7 @@ pub async fn fetch_prekeys<T: StoreType, R: Rng + CryptoRng>(
         )
         .await
         .inspect_err(|e| debug!("{e}"))
-        .map_err(|_| ClientError::FailedToProcessPrekeyBundle)?;
+        .map_err(|_| LogicError::FailedToProcessPrekeyBundle)?;
     }
     Ok(())
 }
@@ -64,7 +65,7 @@ pub async fn publish_prekeys<T: StoreType, R: Rng + CryptoRng>(
     new_signed_prekey: bool,
     new_last_resort: bool,
     mut rng: &mut R,
-) -> Result<(), ClientError> {
+) -> Result<(), LogicError> {
     let id_pair = store.identity_key_store.get_identity_key_pair().await?;
     let onetime_ec_prekeys =
         generate_ec_pre_keys(&mut store.pre_key_store, onetime_prekeys, &mut rng).await?;

--- a/client/src/logic/key.rs
+++ b/client/src/logic/key.rs
@@ -1,7 +1,9 @@
 use std::time::SystemTime;
 
 use libsignal_core::ProtocolAddress;
-use libsignal_protocol::{process_prekey_bundle, IdentityKeyStore};
+use libsignal_protocol::{
+    kem, process_prekey_bundle, IdentityKey, IdentityKeyStore, PreKeyBundle, PublicKey,
+};
 use log::debug;
 use rand::{CryptoRng, Rng};
 use sam_common::{api::PublishPreKeys, AccountId, DeviceId};
@@ -10,7 +12,7 @@ use crate::{
     net::ApiClient,
     storage::{
         key_generation::{
-            generate_ec_pre_keys, generate_pq_pre_keys, into_libsignal_bundle, KyberKeyGenerator,
+            generate_ec_pre_keys, generate_pq_pre_keys, KyberKeyGenerator,
             SignedPreKeyGenerator,
         },
         AccountStore, ContactStore, Store, StoreType,
@@ -101,4 +103,27 @@ pub async fn publish_prekeys<T: StoreType, R: Rng + CryptoRng>(
             },
         )
         .await?)
+}
+
+pub fn into_libsignal_bundle(
+    bundle: sam_common::api::PreKeyBundle,
+    identity_key: IdentityKey,
+) -> Result<PreKeyBundle, LogicError> {
+    Ok(PreKeyBundle::new(
+        bundle.registration_id,
+        bundle.device_id.into(),
+        match bundle.pre_key {
+            None => None,
+            Some(key) => Some((key.key_id.into(), PublicKey::deserialize(&key.public_key)?)),
+        },
+        bundle.signed_pre_key.key_id.into(),
+        PublicKey::deserialize(&bundle.signed_pre_key.public_key)?,
+        bundle.signed_pre_key.signature.to_vec(),
+        identity_key,
+    )?
+    .with_kyber_pre_key(
+        bundle.pq_pre_key.key_id.into(),
+        kem::PublicKey::deserialize(&bundle.pq_pre_key.public_key)?,
+        bundle.pq_pre_key.signature.to_vec(),
+    ))
 }

--- a/client/src/logic/key.rs
+++ b/client/src/logic/key.rs
@@ -12,8 +12,7 @@ use crate::{
     net::ApiClient,
     storage::{
         key_generation::{
-            generate_ec_pre_keys, generate_pq_pre_keys, KyberKeyGenerator,
-            SignedPreKeyGenerator,
+            generate_ec_pre_keys, generate_pq_pre_keys, KyberKeyGenerator, SignedPreKeyGenerator,
         },
         AccountStore, ContactStore, Store, StoreType,
     },

--- a/client/src/logic/message.rs
+++ b/client/src/logic/message.rs
@@ -47,7 +47,8 @@ pub async fn process_message(
         .add_device(envelope.source_account_id(), envelope.source_device_id())
         .await?;
 
-    store.message_store.store_message(envelope).await
+    store.message_store.store_message(envelope).await?;
+    Ok(())
 }
 
 pub async fn prepare_message<T: StoreType, R: Rng + CryptoRng>(

--- a/client/src/logic/message.rs
+++ b/client/src/logic/message.rs
@@ -10,16 +10,15 @@ use crate::{
     encryption::{decrypt, encrypt},
     net::{protocol::MessageStatus, ApiClient},
     storage::{AccountStore, ContactStore, MessageStore, Store, StoreType},
-    ClientError,
 };
 
-use super::key::fetch_prekeys;
+use super::{key::fetch_prekeys, LogicError};
 
 pub async fn process_messages<T: StoreType>(
     store: &mut Store<T>,
     envelope_queue: &mut Receiver<ServerEnvelope>,
     block: bool,
-) -> Result<(), ClientError> {
+) -> Result<(), LogicError> {
     if !block && envelope_queue.is_empty() {
         return Ok(());
     }
@@ -39,7 +38,7 @@ pub async fn process_messages<T: StoreType>(
 pub async fn process_message(
     envelope: ServerEnvelope,
     store: &mut Store<impl StoreType>,
-) -> Result<(), ClientError> {
+) -> Result<(), LogicError> {
     let envelope = decrypt(envelope, store).await?;
 
     store
@@ -57,7 +56,7 @@ pub async fn prepare_message<T: StoreType, R: Rng + CryptoRng>(
     recipient: AccountId,
     msg: impl Into<Vec<u8>>,
     mut rng: &mut R,
-) -> Result<ClientEnvelope, ClientError> {
+) -> Result<ClientEnvelope, LogicError> {
     if !store.contact_store.contains_contact(recipient).await? {
         fetch_prekeys(store, api_client, recipient, None, &mut rng).await?;
     }
@@ -75,7 +74,7 @@ pub async fn handle_message_response<T: StoreType, R: Rng + CryptoRng>(
     api_client: &impl ApiClient,
     mut rng: &mut R,
     status: MessageStatus,
-) -> Result<(), ClientError> {
+) -> Result<(), LogicError> {
     match status {
         MessageStatus::ExtraDevices(device_lists) => {
             for list in device_lists {
@@ -99,7 +98,7 @@ pub async fn handle_message_response<T: StoreType, R: Rng + CryptoRng>(
                 )
                 .await?;
             }
-            Err(ClientError::MissingDevices)
+            Err(LogicError::MissingDevices)
         }
         MessageStatus::Ok => Ok(()),
     }

--- a/client/src/logic/mod.rs
+++ b/client/src/logic/mod.rs
@@ -1,9 +1,11 @@
 mod account;
 mod device;
+mod error;
 mod key;
 mod message;
 
 pub use account::register_account;
 pub use device::provision_device;
+pub use error::LogicError;
 pub use key::{fetch_prekeys, publish_prekeys};
 pub use message::{handle_message_response, prepare_message, process_message, process_messages};

--- a/client/src/logic/mod.rs
+++ b/client/src/logic/mod.rs
@@ -7,5 +7,5 @@ mod message;
 pub use account::register_account;
 pub use device::provision_device;
 pub use error::LogicError;
-pub use key::{fetch_prekeys, publish_prekeys};
+pub use key::{fetch_prekeys, into_libsignal_bundle, publish_prekeys};
 pub use message::{handle_message_response, prepare_message, process_message, process_messages};

--- a/client/src/storage/error.rs
+++ b/client/src/storage/error.rs
@@ -3,17 +3,43 @@ use libsignal_core::curve::CurveError;
 use libsignal_protocol::SignalProtocolError;
 
 #[derive(Debug, Display, Error, From)]
-pub enum StoreError {
+pub enum StoreCreationError {
+    Database(DatabaseError),
+    SignalProtocol(SignalProtocolError),
+    Curve(CurveError),
+}
+
+#[derive(Debug, Display, Error, From)]
+pub enum AccountStoreError {
+    Database(DatabaseError),
+    NoAccountId,
     #[display("Failed to parse an invalid AccountId: {_0}")]
     #[error(ignore)]
     InvalidAccountId(String),
-    NoDeviceId,
-    NoAccountId,
     NoPassword,
     NoUsername,
+    NoDeviceId,
+}
+
+#[derive(Debug, Display, Error, From)]
+pub enum ContactStoreError {
+    Database(DatabaseError),
+}
+
+#[derive(Debug, Display, Error, From)]
+pub enum MessageStoreError {
+    Database(DatabaseError),
     SendError,
+}
+
+#[derive(Debug, Display, Error, From)]
+pub enum KeyStoreError {
+    Database(DatabaseError),
+    SignalProtocol(SignalProtocolError),
+}
+
+#[derive(Debug, Display, Error, From)]
+pub enum DatabaseError {
     #[from(ignore)]
     Database(#[error(not(source))] String),
-    SignalProtocol(SignalProtocolError),
-    Curve(CurveError),
 }

--- a/client/src/storage/error.rs
+++ b/client/src/storage/error.rs
@@ -1,6 +1,8 @@
-use derive_more::derive::{Display, Error};
+use derive_more::derive::{Display, Error, From};
+use libsignal_core::curve::CurveError;
+use libsignal_protocol::SignalProtocolError;
 
-#[derive(Debug, Display, Error)]
+#[derive(Debug, Display, Error, From)]
 pub enum StoreError {
     #[display("Failed to parse an invalid AccountId: {_0}")]
     #[error(ignore)]
@@ -10,5 +12,8 @@ pub enum StoreError {
     NoPassword,
     NoUsername,
     SendError,
+    #[from(ignore)]
     Database(#[error(not(source))] String),
+    SignalProtocol(SignalProtocolError),
+    Curve(CurveError),
 }

--- a/client/src/storage/error.rs
+++ b/client/src/storage/error.rs
@@ -14,8 +14,7 @@ pub enum AccountStoreError {
     Database(DatabaseError),
     NoAccountId,
     #[display("Failed to parse an invalid AccountId: {_0}")]
-    #[error(ignore)]
-    InvalidAccountId(String),
+    InvalidAccountId(#[error(not(source))] String),
     NoPassword,
     NoUsername,
     NoDeviceId,

--- a/client/src/storage/error.rs
+++ b/client/src/storage/error.rs
@@ -1,0 +1,14 @@
+use derive_more::derive::{Display, Error};
+
+#[derive(Debug, Display, Error)]
+pub enum StoreError {
+    #[display("Failed to parse an invalid AccountId: {_0}")]
+    #[error(ignore)]
+    InvalidAccountId(String),
+    NoDeviceId,
+    NoAccountId,
+    NoPassword,
+    NoUsername,
+    SendError,
+    Database(#[error(not(source))] String),
+}

--- a/client/src/storage/inmem/account.rs
+++ b/client/src/storage/inmem/account.rs
@@ -1,4 +1,5 @@
-use crate::{storage::AccountStore, ClientError};
+use crate::storage::error::StoreError;
+use crate::storage::AccountStore;
 use async_trait::async_trait;
 use sam_common::address::AccountId;
 use sam_common::DeviceId;
@@ -13,34 +14,34 @@ pub struct InMemoryAccountStore {
 
 #[async_trait(?Send)]
 impl AccountStore for InMemoryAccountStore {
-    async fn set_account_id(&mut self, account_id: AccountId) -> Result<(), ClientError> {
+    async fn set_account_id(&mut self, account_id: AccountId) -> Result<(), StoreError> {
         self.account_id = Some(account_id);
         Ok(())
     }
-    async fn get_account_id(&self) -> Result<AccountId, ClientError> {
-        Ok(self.account_id.ok_or(ClientError::NoAccountId)?)
+    async fn get_account_id(&self) -> Result<AccountId, StoreError> {
+        Ok(self.account_id.ok_or(StoreError::NoAccountId)?)
     }
-    async fn set_password(&mut self, password: String) -> Result<(), ClientError> {
+    async fn set_password(&mut self, password: String) -> Result<(), StoreError> {
         self.password = Some(password);
         Ok(())
     }
-    async fn get_password(&self) -> Result<String, ClientError> {
-        Ok(self.password.clone().ok_or(ClientError::NoPassword)?)
+    async fn get_password(&self) -> Result<String, StoreError> {
+        Ok(self.password.clone().ok_or(StoreError::NoPassword)?)
     }
-    async fn set_username(&mut self, username: String) -> Result<(), ClientError> {
+    async fn set_username(&mut self, username: String) -> Result<(), StoreError> {
         self.username = Some(username);
         Ok(())
     }
-    async fn get_username(&self) -> Result<String, ClientError> {
-        Ok(self.username.clone().ok_or(ClientError::NoUsername)?)
+    async fn get_username(&self) -> Result<String, StoreError> {
+        Ok(self.username.clone().ok_or(StoreError::NoUsername)?)
     }
 
-    async fn set_device_id(&mut self, device_id: DeviceId) -> Result<(), ClientError> {
+    async fn set_device_id(&mut self, device_id: DeviceId) -> Result<(), StoreError> {
         self.device_id = Some(device_id);
         Ok(())
     }
 
-    async fn get_device_id(&self) -> Result<DeviceId, ClientError> {
-        Ok(self.device_id.ok_or(ClientError::NoDeviceId)?)
+    async fn get_device_id(&self) -> Result<DeviceId, StoreError> {
+        Ok(self.device_id.ok_or(StoreError::NoDeviceId)?)
     }
 }

--- a/client/src/storage/inmem/account.rs
+++ b/client/src/storage/inmem/account.rs
@@ -1,4 +1,4 @@
-use crate::storage::error::StoreError;
+use crate::storage::error::AccountStoreError;
 use crate::storage::AccountStore;
 use async_trait::async_trait;
 use sam_common::address::AccountId;
@@ -14,34 +14,34 @@ pub struct InMemoryAccountStore {
 
 #[async_trait(?Send)]
 impl AccountStore for InMemoryAccountStore {
-    async fn set_account_id(&mut self, account_id: AccountId) -> Result<(), StoreError> {
+    async fn set_account_id(&mut self, account_id: AccountId) -> Result<(), AccountStoreError> {
         self.account_id = Some(account_id);
         Ok(())
     }
-    async fn get_account_id(&self) -> Result<AccountId, StoreError> {
-        Ok(self.account_id.ok_or(StoreError::NoAccountId)?)
+    async fn get_account_id(&self) -> Result<AccountId, AccountStoreError> {
+        Ok(self.account_id.ok_or(AccountStoreError::NoAccountId)?)
     }
-    async fn set_password(&mut self, password: String) -> Result<(), StoreError> {
+    async fn set_password(&mut self, password: String) -> Result<(), AccountStoreError> {
         self.password = Some(password);
         Ok(())
     }
-    async fn get_password(&self) -> Result<String, StoreError> {
-        Ok(self.password.clone().ok_or(StoreError::NoPassword)?)
+    async fn get_password(&self) -> Result<String, AccountStoreError> {
+        Ok(self.password.clone().ok_or(AccountStoreError::NoPassword)?)
     }
-    async fn set_username(&mut self, username: String) -> Result<(), StoreError> {
+    async fn set_username(&mut self, username: String) -> Result<(), AccountStoreError> {
         self.username = Some(username);
         Ok(())
     }
-    async fn get_username(&self) -> Result<String, StoreError> {
-        Ok(self.username.clone().ok_or(StoreError::NoUsername)?)
+    async fn get_username(&self) -> Result<String, AccountStoreError> {
+        Ok(self.username.clone().ok_or(AccountStoreError::NoUsername)?)
     }
 
-    async fn set_device_id(&mut self, device_id: DeviceId) -> Result<(), StoreError> {
+    async fn set_device_id(&mut self, device_id: DeviceId) -> Result<(), AccountStoreError> {
         self.device_id = Some(device_id);
         Ok(())
     }
 
-    async fn get_device_id(&self) -> Result<DeviceId, StoreError> {
-        Ok(self.device_id.ok_or(StoreError::NoDeviceId)?)
+    async fn get_device_id(&self) -> Result<DeviceId, AccountStoreError> {
+        Ok(self.device_id.ok_or(AccountStoreError::NoDeviceId)?)
     }
 }

--- a/client/src/storage/inmem/contact.rs
+++ b/client/src/storage/inmem/contact.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use async_trait::async_trait;
 use sam_common::{AccountId, DeviceId};
 
-use crate::{storage::ContactStore, ClientError};
+use crate::storage::{error::StoreError, ContactStore};
 
 #[derive(Debug, Default)]
 pub struct InMemoryContactStore {
@@ -12,21 +12,21 @@ pub struct InMemoryContactStore {
 
 #[async_trait(?Send)]
 impl ContactStore for InMemoryContactStore {
-    async fn contains_contact(&self, account_id: AccountId) -> Result<bool, ClientError> {
+    async fn contains_contact(&self, account_id: AccountId) -> Result<bool, StoreError> {
         Ok(self.contacts.contains_key(&account_id))
     }
 
     async fn get_all_devices(
         &self,
         account_id: AccountId,
-    ) -> Result<HashSet<DeviceId>, ClientError> {
+    ) -> Result<HashSet<DeviceId>, StoreError> {
         Ok(self.contacts.get(&account_id).cloned().unwrap_or_default())
     }
     async fn add_device(
         &mut self,
         account_id: AccountId,
         device_id: DeviceId,
-    ) -> Result<(), ClientError> {
+    ) -> Result<(), StoreError> {
         self.contacts
             .entry(account_id)
             .or_default()
@@ -37,7 +37,7 @@ impl ContactStore for InMemoryContactStore {
         &mut self,
         account_id: AccountId,
         device_id: DeviceId,
-    ) -> Result<(), ClientError> {
+    ) -> Result<(), StoreError> {
         if let Some(devices) = self.contacts.get_mut(&account_id) {
             devices.remove(&device_id);
         }

--- a/client/src/storage/inmem/contact.rs
+++ b/client/src/storage/inmem/contact.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use async_trait::async_trait;
 use sam_common::{AccountId, DeviceId};
 
-use crate::storage::{error::StoreError, ContactStore};
+use crate::storage::{error::ContactStoreError, ContactStore};
 
 #[derive(Debug, Default)]
 pub struct InMemoryContactStore {
@@ -12,21 +12,21 @@ pub struct InMemoryContactStore {
 
 #[async_trait(?Send)]
 impl ContactStore for InMemoryContactStore {
-    async fn contains_contact(&self, account_id: AccountId) -> Result<bool, StoreError> {
+    async fn contains_contact(&self, account_id: AccountId) -> Result<bool, ContactStoreError> {
         Ok(self.contacts.contains_key(&account_id))
     }
 
     async fn get_all_devices(
         &self,
         account_id: AccountId,
-    ) -> Result<HashSet<DeviceId>, StoreError> {
+    ) -> Result<HashSet<DeviceId>, ContactStoreError> {
         Ok(self.contacts.get(&account_id).cloned().unwrap_or_default())
     }
     async fn add_device(
         &mut self,
         account_id: AccountId,
         device_id: DeviceId,
-    ) -> Result<(), StoreError> {
+    ) -> Result<(), ContactStoreError> {
         self.contacts
             .entry(account_id)
             .or_default()
@@ -37,7 +37,7 @@ impl ContactStore for InMemoryContactStore {
         &mut self,
         account_id: AccountId,
         device_id: DeviceId,
-    ) -> Result<(), StoreError> {
+    ) -> Result<(), ContactStoreError> {
         if let Some(devices) = self.contacts.get_mut(&account_id) {
             devices.remove(&device_id);
         }

--- a/client/src/storage/inmem/kyber.rs
+++ b/client/src/storage/inmem/kyber.rs
@@ -1,11 +1,11 @@
 use async_trait::async_trait;
 use libsignal_protocol::{InMemKyberPreKeyStore, KyberPreKeyId};
 
-use crate::storage::{error::StoreError, ProvidesKeyId};
+use crate::storage::{error::KeyStoreError, ProvidesKeyId};
 
 #[async_trait(?Send)]
 impl ProvidesKeyId<KyberPreKeyId> for InMemKyberPreKeyStore {
-    async fn next_key_id(&self) -> Result<KyberPreKeyId, StoreError> {
+    async fn next_key_id(&self) -> Result<KyberPreKeyId, KeyStoreError> {
         let max: u32 = self
             .all_kyber_pre_key_ids()
             .max()

--- a/client/src/storage/inmem/kyber.rs
+++ b/client/src/storage/inmem/kyber.rs
@@ -1,11 +1,11 @@
 use async_trait::async_trait;
 use libsignal_protocol::{InMemKyberPreKeyStore, KyberPreKeyId};
 
-use crate::{storage::ProvidesKeyId, ClientError};
+use crate::storage::{error::StoreError, ProvidesKeyId};
 
 #[async_trait(?Send)]
 impl ProvidesKeyId<KyberPreKeyId> for InMemKyberPreKeyStore {
-    async fn next_key_id(&self) -> Result<KyberPreKeyId, ClientError> {
+    async fn next_key_id(&self) -> Result<KyberPreKeyId, StoreError> {
         let max: u32 = self
             .all_kyber_pre_key_ids()
             .max()

--- a/client/src/storage/inmem/message.rs
+++ b/client/src/storage/inmem/message.rs
@@ -4,7 +4,7 @@ use tokio::sync::broadcast::{self, Receiver, Sender};
 
 use crate::{
     encryption::envelope::DecryptedEnvelope,
-    storage::{error::StoreError, traits::message::MessageStore},
+    storage::{error::MessageStoreError, traits::message::MessageStore},
 };
 
 pub struct InMemoryMessageStore {
@@ -24,12 +24,15 @@ impl InMemoryMessageStore {
 
 #[async_trait(?Send)]
 impl MessageStore for InMemoryMessageStore {
-    async fn store_message(&mut self, envelope: DecryptedEnvelope) -> Result<(), StoreError> {
+    async fn store_message(
+        &mut self,
+        envelope: DecryptedEnvelope,
+    ) -> Result<(), MessageStoreError> {
         self.messages.push(envelope.clone());
         self.sender
             .send(envelope)
             .inspect_err(|e| debug!("{e}"))
-            .map_err(|_| StoreError::SendError)
+            .map_err(|_| MessageStoreError::SendError)
             .map(|_| ())
     }
     fn subscribe(&self) -> Receiver<DecryptedEnvelope> {

--- a/client/src/storage/inmem/message.rs
+++ b/client/src/storage/inmem/message.rs
@@ -3,7 +3,8 @@ use log::debug;
 use tokio::sync::broadcast::{self, Receiver, Sender};
 
 use crate::{
-    encryption::envelope::DecryptedEnvelope, storage::traits::message::MessageStore, ClientError,
+    encryption::envelope::DecryptedEnvelope,
+    storage::{error::StoreError, traits::message::MessageStore},
 };
 
 pub struct InMemoryMessageStore {
@@ -23,12 +24,12 @@ impl InMemoryMessageStore {
 
 #[async_trait(?Send)]
 impl MessageStore for InMemoryMessageStore {
-    async fn store_message(&mut self, envelope: DecryptedEnvelope) -> Result<(), ClientError> {
+    async fn store_message(&mut self, envelope: DecryptedEnvelope) -> Result<(), StoreError> {
         self.messages.push(envelope.clone());
         self.sender
             .send(envelope)
             .inspect_err(|e| debug!("{e}"))
-            .map_err(|_| ClientError::SendError)
+            .map_err(|_| StoreError::SendError)
             .map(|_| ())
     }
     fn subscribe(&self) -> Receiver<DecryptedEnvelope> {

--- a/client/src/storage/inmem/mod.rs
+++ b/client/src/storage/inmem/mod.rs
@@ -1,5 +1,4 @@
-use super::{Store, StoreConfig, StoreType};
-use crate::ClientError;
+use super::{error::StoreCreationError, Store, StoreConfig, StoreType};
 pub use account::InMemoryAccountStore;
 use async_trait::async_trait;
 pub use contact::InMemoryContactStore;
@@ -51,7 +50,7 @@ impl StoreConfig for InMemoryStoreConfig {
         self,
         key_pair: IdentityKeyPair,
         registration_id: ID,
-    ) -> Result<InMemoryStore, ClientError> {
+    ) -> Result<InMemoryStore, StoreCreationError> {
         Ok(InMemoryStore::builder()
             .identity_key_store(InMemIdentityKeyStore::new(key_pair, registration_id.into()))
             .pre_key_store(InMemPreKeyStore::default())

--- a/client/src/storage/inmem/pre_key.rs
+++ b/client/src/storage/inmem/pre_key.rs
@@ -1,11 +1,11 @@
 use async_trait::async_trait;
 use libsignal_protocol::{InMemPreKeyStore, PreKeyId};
 
-use crate::{storage::ProvidesKeyId, ClientError};
+use crate::storage::{error::StoreError, ProvidesKeyId};
 
 #[async_trait(?Send)]
 impl ProvidesKeyId<PreKeyId> for InMemPreKeyStore {
-    async fn next_key_id(&self) -> Result<PreKeyId, ClientError> {
+    async fn next_key_id(&self) -> Result<PreKeyId, StoreError> {
         let max: u32 = self
             .all_pre_key_ids()
             .max()

--- a/client/src/storage/inmem/pre_key.rs
+++ b/client/src/storage/inmem/pre_key.rs
@@ -1,11 +1,11 @@
 use async_trait::async_trait;
 use libsignal_protocol::{InMemPreKeyStore, PreKeyId};
 
-use crate::storage::{error::StoreError, ProvidesKeyId};
+use crate::storage::{error::KeyStoreError, ProvidesKeyId};
 
 #[async_trait(?Send)]
 impl ProvidesKeyId<PreKeyId> for InMemPreKeyStore {
-    async fn next_key_id(&self) -> Result<PreKeyId, StoreError> {
+    async fn next_key_id(&self) -> Result<PreKeyId, KeyStoreError> {
         let max: u32 = self
             .all_pre_key_ids()
             .max()

--- a/client/src/storage/inmem/signed_pre_key.rs
+++ b/client/src/storage/inmem/signed_pre_key.rs
@@ -1,11 +1,10 @@
-use crate::storage::ProvidesKeyId;
-use crate::ClientError;
+use crate::storage::{error::StoreError, ProvidesKeyId};
 use async_trait::async_trait;
 use libsignal_protocol::{InMemSignedPreKeyStore, SignedPreKeyId};
 
 #[async_trait(?Send)]
 impl ProvidesKeyId<SignedPreKeyId> for InMemSignedPreKeyStore {
-    async fn next_key_id(&self) -> Result<SignedPreKeyId, ClientError> {
+    async fn next_key_id(&self) -> Result<SignedPreKeyId, StoreError> {
         let max: u32 = self
             .all_signed_pre_key_ids()
             .max()

--- a/client/src/storage/inmem/signed_pre_key.rs
+++ b/client/src/storage/inmem/signed_pre_key.rs
@@ -1,10 +1,10 @@
-use crate::storage::{error::StoreError, ProvidesKeyId};
+use crate::storage::{error::KeyStoreError, ProvidesKeyId};
 use async_trait::async_trait;
 use libsignal_protocol::{InMemSignedPreKeyStore, SignedPreKeyId};
 
 #[async_trait(?Send)]
 impl ProvidesKeyId<SignedPreKeyId> for InMemSignedPreKeyStore {
-    async fn next_key_id(&self) -> Result<SignedPreKeyId, StoreError> {
+    async fn next_key_id(&self) -> Result<SignedPreKeyId, KeyStoreError> {
         let max: u32 = self
             .all_signed_pre_key_ids()
             .max()

--- a/client/src/storage/key_generation.rs
+++ b/client/src/storage/key_generation.rs
@@ -1,5 +1,5 @@
+use crate::signal_time_now;
 use crate::storage::{ProvidesKeyId, Store, StoreType};
-use crate::{signal_time_now, ClientError};
 use async_trait::async_trait;
 use libsignal_core::curve::{KeyPair, PrivateKey};
 use libsignal_protocol::kem::{self, KeyType};
@@ -13,12 +13,14 @@ use rand::{CryptoRng, Rng};
 use sam_common::api::keys::RegistrationPreKeys;
 use sam_common::api::{EcPreKey, PqPreKey};
 
+use super::error::StoreError;
+
 #[async_trait(?Send)]
 pub trait PreKeyGenerator {
     async fn generate_key<R: Rng + CryptoRng>(
         &mut self,
         csprng: &mut R,
-    ) -> Result<PreKeyRecord, ClientError>;
+    ) -> Result<PreKeyRecord, StoreError>;
 }
 
 pub async fn generate_ec_pre_key<R: Rng + CryptoRng>(id: PreKeyId, csprng: &mut R) -> PreKeyRecord {
@@ -28,7 +30,7 @@ pub async fn generate_ec_pre_key<R: Rng + CryptoRng>(id: PreKeyId, csprng: &mut 
 
 #[async_trait(?Send)]
 impl<T: PreKeyStore + ProvidesKeyId<PreKeyId>> PreKeyGenerator for T {
-    async fn generate_key<R>(&mut self, csprng: &mut R) -> Result<PreKeyRecord, ClientError>
+    async fn generate_key<R>(&mut self, csprng: &mut R) -> Result<PreKeyRecord, StoreError>
     where
         R: Rng + CryptoRng,
     {
@@ -46,7 +48,7 @@ pub trait SignedPreKeyGenerator {
         &mut self,
         csprng: &mut R,
         private_key: &PrivateKey,
-    ) -> Result<SignedPreKeyRecord, ClientError>;
+    ) -> Result<SignedPreKeyRecord, StoreError>;
 }
 
 pub async fn generate_signed_pre_key<R: Rng + CryptoRng>(
@@ -72,7 +74,7 @@ impl<T: SignedPreKeyStore + ProvidesKeyId<SignedPreKeyId>> SignedPreKeyGenerator
         &mut self,
         csprng: &mut R,
         private_key: &PrivateKey,
-    ) -> Result<SignedPreKeyRecord, ClientError>
+    ) -> Result<SignedPreKeyRecord, StoreError>
     where
         R: Rng + CryptoRng,
     {
@@ -89,7 +91,7 @@ pub trait KyberKeyGenerator {
     async fn generate_key(
         &mut self,
         private_key: &PrivateKey,
-    ) -> Result<KyberPreKeyRecord, ClientError>;
+    ) -> Result<KyberPreKeyRecord, StoreError>;
 }
 
 pub async fn generate_pq_pre_key(
@@ -104,7 +106,7 @@ impl<T: KyberPreKeyStore + ProvidesKeyId<KyberPreKeyId>> KyberKeyGenerator for T
     async fn generate_key(
         &mut self,
         private_key: &PrivateKey,
-    ) -> Result<KyberPreKeyRecord, ClientError> {
+    ) -> Result<KyberPreKeyRecord, StoreError> {
         let id = self.next_key_id().await?;
         let record = generate_pq_pre_key(id, private_key).await?;
         self.save_kyber_pre_key(id, &record).await?;
@@ -116,7 +118,7 @@ pub async fn generate_ec_pre_keys<G: PreKeyGenerator, R: Rng + CryptoRng>(
     generator: &mut G,
     amount: usize,
     mut csprng: &mut R,
-) -> Result<Vec<EcPreKey>, ClientError> {
+) -> Result<Vec<EcPreKey>, StoreError> {
     let mut keys = Vec::with_capacity(amount);
     for _ in 0..amount {
         keys.push(generator.generate_key(&mut csprng).await?.into());
@@ -128,7 +130,7 @@ pub async fn generate_pq_pre_keys<G: KyberKeyGenerator>(
     signing_key: &PrivateKey,
     generator: &mut G,
     amount: usize,
-) -> Result<Vec<PqPreKey>, ClientError> {
+) -> Result<Vec<PqPreKey>, StoreError> {
     let mut keys = Vec::with_capacity(amount);
     for _ in 0..amount {
         keys.push(generator.generate_key(signing_key).await?.into());
@@ -139,7 +141,7 @@ pub async fn generate_pq_pre_keys<G: KyberKeyGenerator>(
 pub fn into_libsignal_bundle(
     bundle: sam_common::api::PreKeyBundle,
     identity_key: IdentityKey,
-) -> Result<PreKeyBundle, ClientError> {
+) -> Result<PreKeyBundle, StoreError> {
     Ok(PreKeyBundle::new(
         bundle.registration_id,
         bundle.device_id.into(),
@@ -164,7 +166,7 @@ pub async fn create_registration_pre_keys<S: StoreType, R: Rng + CryptoRng>(
     prekey_count: usize,
     id_key_pair: IdentityKeyPair,
     mut csprng: &mut R,
-) -> Result<RegistrationPreKeys, ClientError> {
+) -> Result<RegistrationPreKeys, StoreError> {
     Ok(RegistrationPreKeys {
         pre_keys: Some(
             generate_ec_pre_keys(&mut store.pre_key_store, prekey_count, &mut csprng).await?,

--- a/client/src/storage/key_generation.rs
+++ b/client/src/storage/key_generation.rs
@@ -2,25 +2,25 @@ use crate::signal_time_now;
 use crate::storage::{ProvidesKeyId, Store, StoreType};
 use async_trait::async_trait;
 use libsignal_core::curve::{KeyPair, PrivateKey};
-use libsignal_protocol::kem::{self, KeyType};
+use libsignal_protocol::kem::KeyType;
 use libsignal_protocol::{
-    GenericSignedPreKey, IdentityKey, IdentityKeyPair, KyberPreKeyId, KyberPreKeyRecord,
-    KyberPreKeyStore, PreKeyBundle, PreKeyId, PreKeyRecord, PreKeyStore, PublicKey,
-    SignalProtocolError, SignedPreKeyId, SignedPreKeyRecord, SignedPreKeyStore,
+    GenericSignedPreKey, IdentityKeyPair, KyberPreKeyId, KyberPreKeyRecord, KyberPreKeyStore,
+    PreKeyId, PreKeyRecord, PreKeyStore, SignalProtocolError, SignedPreKeyId, SignedPreKeyRecord,
+    SignedPreKeyStore,
 };
 
 use rand::{CryptoRng, Rng};
 use sam_common::api::keys::RegistrationPreKeys;
 use sam_common::api::{EcPreKey, PqPreKey};
 
-use super::error::StoreError;
+use super::error::KeyStoreError;
 
 #[async_trait(?Send)]
 pub trait PreKeyGenerator {
     async fn generate_key<R: Rng + CryptoRng>(
         &mut self,
         csprng: &mut R,
-    ) -> Result<PreKeyRecord, StoreError>;
+    ) -> Result<PreKeyRecord, KeyStoreError>;
 }
 
 pub async fn generate_ec_pre_key<R: Rng + CryptoRng>(id: PreKeyId, csprng: &mut R) -> PreKeyRecord {
@@ -30,7 +30,7 @@ pub async fn generate_ec_pre_key<R: Rng + CryptoRng>(id: PreKeyId, csprng: &mut 
 
 #[async_trait(?Send)]
 impl<T: PreKeyStore + ProvidesKeyId<PreKeyId>> PreKeyGenerator for T {
-    async fn generate_key<R>(&mut self, csprng: &mut R) -> Result<PreKeyRecord, StoreError>
+    async fn generate_key<R>(&mut self, csprng: &mut R) -> Result<PreKeyRecord, KeyStoreError>
     where
         R: Rng + CryptoRng,
     {
@@ -48,7 +48,7 @@ pub trait SignedPreKeyGenerator {
         &mut self,
         csprng: &mut R,
         private_key: &PrivateKey,
-    ) -> Result<SignedPreKeyRecord, StoreError>;
+    ) -> Result<SignedPreKeyRecord, KeyStoreError>;
 }
 
 pub async fn generate_signed_pre_key<R: Rng + CryptoRng>(
@@ -74,7 +74,7 @@ impl<T: SignedPreKeyStore + ProvidesKeyId<SignedPreKeyId>> SignedPreKeyGenerator
         &mut self,
         csprng: &mut R,
         private_key: &PrivateKey,
-    ) -> Result<SignedPreKeyRecord, StoreError>
+    ) -> Result<SignedPreKeyRecord, KeyStoreError>
     where
         R: Rng + CryptoRng,
     {
@@ -91,7 +91,7 @@ pub trait KyberKeyGenerator {
     async fn generate_key(
         &mut self,
         private_key: &PrivateKey,
-    ) -> Result<KyberPreKeyRecord, StoreError>;
+    ) -> Result<KyberPreKeyRecord, KeyStoreError>;
 }
 
 pub async fn generate_pq_pre_key(
@@ -106,7 +106,7 @@ impl<T: KyberPreKeyStore + ProvidesKeyId<KyberPreKeyId>> KyberKeyGenerator for T
     async fn generate_key(
         &mut self,
         private_key: &PrivateKey,
-    ) -> Result<KyberPreKeyRecord, StoreError> {
+    ) -> Result<KyberPreKeyRecord, KeyStoreError> {
         let id = self.next_key_id().await?;
         let record = generate_pq_pre_key(id, private_key).await?;
         self.save_kyber_pre_key(id, &record).await?;
@@ -118,7 +118,7 @@ pub async fn generate_ec_pre_keys<G: PreKeyGenerator, R: Rng + CryptoRng>(
     generator: &mut G,
     amount: usize,
     mut csprng: &mut R,
-) -> Result<Vec<EcPreKey>, StoreError> {
+) -> Result<Vec<EcPreKey>, KeyStoreError> {
     let mut keys = Vec::with_capacity(amount);
     for _ in 0..amount {
         keys.push(generator.generate_key(&mut csprng).await?.into());
@@ -130,7 +130,7 @@ pub async fn generate_pq_pre_keys<G: KyberKeyGenerator>(
     signing_key: &PrivateKey,
     generator: &mut G,
     amount: usize,
-) -> Result<Vec<PqPreKey>, StoreError> {
+) -> Result<Vec<PqPreKey>, KeyStoreError> {
     let mut keys = Vec::with_capacity(amount);
     for _ in 0..amount {
         keys.push(generator.generate_key(signing_key).await?.into());
@@ -138,35 +138,12 @@ pub async fn generate_pq_pre_keys<G: KyberKeyGenerator>(
     Ok(keys)
 }
 
-pub fn into_libsignal_bundle(
-    bundle: sam_common::api::PreKeyBundle,
-    identity_key: IdentityKey,
-) -> Result<PreKeyBundle, StoreError> {
-    Ok(PreKeyBundle::new(
-        bundle.registration_id,
-        bundle.device_id.into(),
-        match bundle.pre_key {
-            None => None,
-            Some(key) => Some((key.key_id.into(), PublicKey::deserialize(&key.public_key)?)),
-        },
-        bundle.signed_pre_key.key_id.into(),
-        PublicKey::deserialize(&bundle.signed_pre_key.public_key)?,
-        bundle.signed_pre_key.signature.to_vec(),
-        identity_key,
-    )?
-    .with_kyber_pre_key(
-        bundle.pq_pre_key.key_id.into(),
-        kem::PublicKey::deserialize(&bundle.pq_pre_key.public_key)?,
-        bundle.pq_pre_key.signature.to_vec(),
-    ))
-}
-
 pub async fn create_registration_pre_keys<S: StoreType, R: Rng + CryptoRng>(
     store: &mut Store<S>,
     prekey_count: usize,
     id_key_pair: IdentityKeyPair,
     mut csprng: &mut R,
-) -> Result<RegistrationPreKeys, StoreError> {
+) -> Result<RegistrationPreKeys, KeyStoreError> {
     Ok(RegistrationPreKeys {
         pre_keys: Some(
             generate_ec_pre_keys(&mut store.pre_key_store, prekey_count, &mut csprng).await?,

--- a/client/src/storage/mod.rs
+++ b/client/src/storage/mod.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use bon::Builder;
-use error::StoreError;
+use error::{KeyStoreError, StoreCreationError};
 use libsignal_protocol::{
     IdentityKeyPair, IdentityKeyStore, KyberPreKeyId, KyberPreKeyStore, PreKeyId, PreKeyStore,
     SenderKeyStore, SessionStore, SignedPreKeyId, SignedPreKeyStore,
@@ -8,7 +8,6 @@ use libsignal_protocol::{
 use std::fmt::Debug;
 
 use crate::storage::key_generation::{KyberKeyGenerator, PreKeyGenerator, SignedPreKeyGenerator};
-use crate::ClientError;
 
 pub mod error;
 pub mod inmem;
@@ -35,12 +34,12 @@ pub trait StoreConfig {
         self,
         key_pair: IdentityKeyPair,
         registration_id: ID,
-    ) -> Result<Store<Self::StoreType>, ClientError>;
+    ) -> Result<Store<Self::StoreType>, StoreCreationError>;
 }
 
 #[async_trait(?Send)]
 pub trait ProvidesKeyId<T> {
-    async fn next_key_id(&self) -> Result<T, StoreError>;
+    async fn next_key_id(&self) -> Result<T, KeyStoreError>;
 }
 
 pub trait StoreType {

--- a/client/src/storage/mod.rs
+++ b/client/src/storage/mod.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use bon::Builder;
+use error::StoreError;
 use libsignal_protocol::{
     IdentityKeyPair, IdentityKeyStore, KyberPreKeyId, KyberPreKeyStore, PreKeyId, PreKeyStore,
     SenderKeyStore, SessionStore, SignedPreKeyId, SignedPreKeyStore,
@@ -9,6 +10,7 @@ use std::fmt::Debug;
 use crate::storage::key_generation::{KyberKeyGenerator, PreKeyGenerator, SignedPreKeyGenerator};
 use crate::ClientError;
 
+pub mod error;
 pub mod inmem;
 pub mod key_generation;
 pub mod sqlite;
@@ -38,7 +40,7 @@ pub trait StoreConfig {
 
 #[async_trait(?Send)]
 pub trait ProvidesKeyId<T> {
-    async fn next_key_id(&self) -> Result<T, ClientError>;
+    async fn next_key_id(&self) -> Result<T, StoreError>;
 }
 
 pub trait StoreType {

--- a/client/src/storage/sqlite/account.rs
+++ b/client/src/storage/sqlite/account.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr as _;
 
-use crate::{storage::AccountStore, ClientError};
+use crate::storage::{error::StoreError, AccountStore};
 use async_trait::async_trait;
 use log::debug;
 use sam_common::address::AccountId;
@@ -20,7 +20,7 @@ impl SqliteAccountStore {
 
 #[async_trait(?Send)]
 impl AccountStore for SqliteAccountStore {
-    async fn set_account_id(&mut self, id: AccountId) -> Result<(), ClientError> {
+    async fn set_account_id(&mut self, id: AccountId) -> Result<(), StoreError> {
         let aci = id.to_string();
         sqlx::query!(
             r#"
@@ -33,10 +33,10 @@ impl AccountStore for SqliteAccountStore {
         .execute(&self.database)
         .await
         .map(|_| ())
-        .map_err(|err| ClientError::Database(format!("{err}")))
+        .map_err(|err| StoreError::Database(format!("{err}")))
     }
 
-    async fn get_account_id(&self) -> Result<AccountId, ClientError> {
+    async fn get_account_id(&self) -> Result<AccountId, StoreError> {
         match sqlx::query!(
             r#"
             SELECT * FROM AccountId;
@@ -46,15 +46,15 @@ impl AccountStore for SqliteAccountStore {
         .await
         .inspect_err(|e| debug!("{e}"))
         {
-            Err(SqlxError::RowNotFound) => Err(ClientError::NoAccountId),
+            Err(SqlxError::RowNotFound) => Err(StoreError::NoAccountId),
             Ok(rec) => AccountId::from_str(&rec.account_id)
                 .inspect_err(|e| debug!("{e}"))
-                .map_err(|_| ClientError::InvalidAccountId(rec.account_id)),
-            Err(err) => Err(ClientError::Database(format!("{err}"))),
+                .map_err(|_| StoreError::InvalidAccountId(rec.account_id)),
+            Err(err) => Err(StoreError::Database(format!("{err}"))),
         }
     }
 
-    async fn set_password(&mut self, password: String) -> Result<(), ClientError> {
+    async fn set_password(&mut self, password: String) -> Result<(), StoreError> {
         sqlx::query!(
             r#"
             DELETE FROM Password;
@@ -66,10 +66,10 @@ impl AccountStore for SqliteAccountStore {
         .execute(&self.database)
         .await
         .map(|_| ())
-        .map_err(|err| ClientError::Database(format!("{err}")))
+        .map_err(|err| StoreError::Database(format!("{err}")))
     }
 
-    async fn get_password(&self) -> Result<String, ClientError> {
+    async fn get_password(&self) -> Result<String, StoreError> {
         match sqlx::query!(
             r#"
             SELECT * FROM Password;
@@ -78,13 +78,13 @@ impl AccountStore for SqliteAccountStore {
         .fetch_one(&self.database)
         .await
         {
-            Err(SqlxError::RowNotFound) => Err(ClientError::NoPassword),
+            Err(SqlxError::RowNotFound) => Err(StoreError::NoPassword),
             Ok(rec) => Ok(rec.password),
-            Err(err) => Err(ClientError::Database(format!("{err}"))),
+            Err(err) => Err(StoreError::Database(format!("{err}"))),
         }
     }
 
-    async fn set_username(&mut self, username: String) -> Result<(), ClientError> {
+    async fn set_username(&mut self, username: String) -> Result<(), StoreError> {
         sqlx::query!(
             r#"
             DELETE FROM Username;
@@ -96,10 +96,10 @@ impl AccountStore for SqliteAccountStore {
         .execute(&self.database)
         .await
         .map(|_| ())
-        .map_err(|err| ClientError::Database(format!("{err}")))
+        .map_err(|err| StoreError::Database(format!("{err}")))
     }
 
-    async fn get_username(&self) -> Result<String, ClientError> {
+    async fn get_username(&self) -> Result<String, StoreError> {
         match sqlx::query!(
             r#"
             SELECT * FROM Username;
@@ -108,13 +108,13 @@ impl AccountStore for SqliteAccountStore {
         .fetch_one(&self.database)
         .await
         {
-            Err(SqlxError::RowNotFound) => Err(ClientError::NoUsername),
+            Err(SqlxError::RowNotFound) => Err(StoreError::NoUsername),
             Ok(rec) => Ok(rec.username),
-            Err(err) => Err(ClientError::Database(format!("{err}"))),
+            Err(err) => Err(StoreError::Database(format!("{err}"))),
         }
     }
 
-    async fn set_device_id(&mut self, device_id: DeviceId) -> Result<(), ClientError> {
+    async fn set_device_id(&mut self, device_id: DeviceId) -> Result<(), StoreError> {
         let dev_id = Into::<u32>::into(device_id);
         sqlx::query!(
             r#"
@@ -127,10 +127,10 @@ impl AccountStore for SqliteAccountStore {
         .execute(&self.database)
         .await
         .map(|_| ())
-        .map_err(|err| ClientError::Database(format!("{err}")))
+        .map_err(|err| StoreError::Database(format!("{err}")))
     }
 
-    async fn get_device_id(&self) -> Result<DeviceId, ClientError> {
+    async fn get_device_id(&self) -> Result<DeviceId, StoreError> {
         match sqlx::query!(
             r#"
             SELECT * FROM DeviceId;
@@ -139,9 +139,9 @@ impl AccountStore for SqliteAccountStore {
         .fetch_one(&self.database)
         .await
         {
-            Err(SqlxError::RowNotFound) => Err(ClientError::NoDeviceId),
+            Err(SqlxError::RowNotFound) => Err(StoreError::NoDeviceId),
             Ok(rec) => Ok((rec.device_id as u32).into()),
-            Err(err) => Err(ClientError::Database(format!("{err}"))),
+            Err(err) => Err(StoreError::Database(format!("{err}"))),
         }
     }
 }

--- a/client/src/storage/sqlite/account.rs
+++ b/client/src/storage/sqlite/account.rs
@@ -1,6 +1,9 @@
 use std::str::FromStr as _;
 
-use crate::storage::{error::StoreError, AccountStore};
+use crate::storage::{
+    error::{AccountStoreError, DatabaseError},
+    AccountStore,
+};
 use async_trait::async_trait;
 use log::debug;
 use sam_common::address::AccountId;
@@ -20,7 +23,7 @@ impl SqliteAccountStore {
 
 #[async_trait(?Send)]
 impl AccountStore for SqliteAccountStore {
-    async fn set_account_id(&mut self, id: AccountId) -> Result<(), StoreError> {
+    async fn set_account_id(&mut self, id: AccountId) -> Result<(), AccountStoreError> {
         let aci = id.to_string();
         sqlx::query!(
             r#"
@@ -33,10 +36,10 @@ impl AccountStore for SqliteAccountStore {
         .execute(&self.database)
         .await
         .map(|_| ())
-        .map_err(|err| StoreError::Database(format!("{err}")))
+        .map_err(|err| DatabaseError::Database(format!("{err}")).into())
     }
 
-    async fn get_account_id(&self) -> Result<AccountId, StoreError> {
+    async fn get_account_id(&self) -> Result<AccountId, AccountStoreError> {
         match sqlx::query!(
             r#"
             SELECT * FROM AccountId;
@@ -46,15 +49,15 @@ impl AccountStore for SqliteAccountStore {
         .await
         .inspect_err(|e| debug!("{e}"))
         {
-            Err(SqlxError::RowNotFound) => Err(StoreError::NoAccountId),
+            Err(SqlxError::RowNotFound) => Err(AccountStoreError::NoAccountId),
             Ok(rec) => AccountId::from_str(&rec.account_id)
                 .inspect_err(|e| debug!("{e}"))
-                .map_err(|_| StoreError::InvalidAccountId(rec.account_id)),
-            Err(err) => Err(StoreError::Database(format!("{err}"))),
+                .map_err(|_| AccountStoreError::InvalidAccountId(rec.account_id)),
+            Err(err) => Err(DatabaseError::Database(format!("{err}")))?,
         }
     }
 
-    async fn set_password(&mut self, password: String) -> Result<(), StoreError> {
+    async fn set_password(&mut self, password: String) -> Result<(), AccountStoreError> {
         sqlx::query!(
             r#"
             DELETE FROM Password;
@@ -66,10 +69,10 @@ impl AccountStore for SqliteAccountStore {
         .execute(&self.database)
         .await
         .map(|_| ())
-        .map_err(|err| StoreError::Database(format!("{err}")))
+        .map_err(|err| DatabaseError::Database(format!("{err}")).into())
     }
 
-    async fn get_password(&self) -> Result<String, StoreError> {
+    async fn get_password(&self) -> Result<String, AccountStoreError> {
         match sqlx::query!(
             r#"
             SELECT * FROM Password;
@@ -78,13 +81,13 @@ impl AccountStore for SqliteAccountStore {
         .fetch_one(&self.database)
         .await
         {
-            Err(SqlxError::RowNotFound) => Err(StoreError::NoPassword),
+            Err(SqlxError::RowNotFound) => Err(AccountStoreError::NoPassword),
             Ok(rec) => Ok(rec.password),
-            Err(err) => Err(StoreError::Database(format!("{err}"))),
+            Err(err) => Err(DatabaseError::Database(format!("{err}")))?,
         }
     }
 
-    async fn set_username(&mut self, username: String) -> Result<(), StoreError> {
+    async fn set_username(&mut self, username: String) -> Result<(), AccountStoreError> {
         sqlx::query!(
             r#"
             DELETE FROM Username;
@@ -96,10 +99,10 @@ impl AccountStore for SqliteAccountStore {
         .execute(&self.database)
         .await
         .map(|_| ())
-        .map_err(|err| StoreError::Database(format!("{err}")))
+        .map_err(|err| DatabaseError::Database(format!("{err}")).into())
     }
 
-    async fn get_username(&self) -> Result<String, StoreError> {
+    async fn get_username(&self) -> Result<String, AccountStoreError> {
         match sqlx::query!(
             r#"
             SELECT * FROM Username;
@@ -108,13 +111,13 @@ impl AccountStore for SqliteAccountStore {
         .fetch_one(&self.database)
         .await
         {
-            Err(SqlxError::RowNotFound) => Err(StoreError::NoUsername),
+            Err(SqlxError::RowNotFound) => Err(AccountStoreError::NoUsername),
             Ok(rec) => Ok(rec.username),
-            Err(err) => Err(StoreError::Database(format!("{err}"))),
+            Err(err) => Err(DatabaseError::Database(format!("{err}")))?,
         }
     }
 
-    async fn set_device_id(&mut self, device_id: DeviceId) -> Result<(), StoreError> {
+    async fn set_device_id(&mut self, device_id: DeviceId) -> Result<(), AccountStoreError> {
         let dev_id = Into::<u32>::into(device_id);
         sqlx::query!(
             r#"
@@ -127,10 +130,10 @@ impl AccountStore for SqliteAccountStore {
         .execute(&self.database)
         .await
         .map(|_| ())
-        .map_err(|err| StoreError::Database(format!("{err}")))
+        .map_err(|err| DatabaseError::Database(format!("{err}")).into())
     }
 
-    async fn get_device_id(&self) -> Result<DeviceId, StoreError> {
+    async fn get_device_id(&self) -> Result<DeviceId, AccountStoreError> {
         match sqlx::query!(
             r#"
             SELECT * FROM DeviceId;
@@ -139,9 +142,9 @@ impl AccountStore for SqliteAccountStore {
         .fetch_one(&self.database)
         .await
         {
-            Err(SqlxError::RowNotFound) => Err(StoreError::NoDeviceId),
+            Err(SqlxError::RowNotFound) => Err(AccountStoreError::NoDeviceId),
             Ok(rec) => Ok((rec.device_id as u32).into()),
-            Err(err) => Err(StoreError::Database(format!("{err}"))),
+            Err(err) => Err(DatabaseError::Database(format!("{err}")))?,
         }
     }
 }

--- a/client/src/storage/sqlite/contact.rs
+++ b/client/src/storage/sqlite/contact.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use sam_common::{AccountId, DeviceId};
 use sqlx::{Pool, Sqlite};
 
-use crate::{storage::ContactStore, ClientError};
+use crate::storage::{error::StoreError, ContactStore};
 
 #[derive(Debug)]
 pub struct SqliteContactStore {
@@ -19,7 +19,7 @@ impl SqliteContactStore {
 
 #[async_trait(?Send)]
 impl ContactStore for SqliteContactStore {
-    async fn contains_contact(&self, account_id: AccountId) -> Result<bool, ClientError> {
+    async fn contains_contact(&self, account_id: AccountId) -> Result<bool, StoreError> {
         let aci_str = account_id.to_string();
         sqlx::query_scalar!(
             r#"
@@ -32,12 +32,12 @@ impl ContactStore for SqliteContactStore {
         .fetch_one(&self.database)
         .await
         .map(|exists| exists == 1)
-        .map_err(|err| ClientError::Database(format!("{err}")))
+        .map_err(|err| StoreError::Database(format!("{err}")))
     }
     async fn get_all_devices(
         &self,
         account_id: AccountId,
-    ) -> Result<HashSet<DeviceId>, ClientError> {
+    ) -> Result<HashSet<DeviceId>, StoreError> {
         let aci_str = account_id.to_string();
         let ids = sqlx::query!(
             r#"
@@ -47,7 +47,7 @@ impl ContactStore for SqliteContactStore {
         )
         .fetch_all(&self.database)
         .await
-        .map_err(|err| ClientError::Database(format!("{err}")))?
+        .map_err(|err| StoreError::Database(format!("{err}")))?
         .into_iter()
         .map(|rec| (rec.device_id as u32).into());
 
@@ -57,7 +57,7 @@ impl ContactStore for SqliteContactStore {
         &mut self,
         account_id: AccountId,
         device_id: DeviceId,
-    ) -> Result<(), ClientError> {
+    ) -> Result<(), StoreError> {
         let aci_str = account_id.to_string();
         let dev_str = device_id.to_string();
         sqlx::query!(
@@ -77,14 +77,14 @@ impl ContactStore for SqliteContactStore {
         .execute(&self.database)
         .await
         .map(|_| ())
-        .map_err(|err| ClientError::Database(format!("{err}")))
+        .map_err(|err| StoreError::Database(format!("{err}")))
     }
 
     async fn remove_device(
         &mut self,
         account_id: AccountId,
         device_id: DeviceId,
-    ) -> Result<(), ClientError> {
+    ) -> Result<(), StoreError> {
         let aci_str = account_id.to_string();
         let dev_str = device_id.to_string();
         sqlx::query!(
@@ -98,6 +98,6 @@ impl ContactStore for SqliteContactStore {
         .execute(&self.database)
         .await
         .map(|_| ())
-        .map_err(|err| ClientError::Database(format!("{err}")))
+        .map_err(|err| StoreError::Database(format!("{err}")))
     }
 }

--- a/client/src/storage/sqlite/contact.rs
+++ b/client/src/storage/sqlite/contact.rs
@@ -4,7 +4,10 @@ use async_trait::async_trait;
 use sam_common::{AccountId, DeviceId};
 use sqlx::{Pool, Sqlite};
 
-use crate::storage::{error::StoreError, ContactStore};
+use crate::storage::{
+    error::{ContactStoreError, DatabaseError},
+    ContactStore,
+};
 
 #[derive(Debug)]
 pub struct SqliteContactStore {
@@ -19,7 +22,7 @@ impl SqliteContactStore {
 
 #[async_trait(?Send)]
 impl ContactStore for SqliteContactStore {
-    async fn contains_contact(&self, account_id: AccountId) -> Result<bool, StoreError> {
+    async fn contains_contact(&self, account_id: AccountId) -> Result<bool, ContactStoreError> {
         let aci_str = account_id.to_string();
         sqlx::query_scalar!(
             r#"
@@ -32,12 +35,12 @@ impl ContactStore for SqliteContactStore {
         .fetch_one(&self.database)
         .await
         .map(|exists| exists == 1)
-        .map_err(|err| StoreError::Database(format!("{err}")))
+        .map_err(|err| DatabaseError::Database(format!("{err}")).into())
     }
     async fn get_all_devices(
         &self,
         account_id: AccountId,
-    ) -> Result<HashSet<DeviceId>, StoreError> {
+    ) -> Result<HashSet<DeviceId>, ContactStoreError> {
         let aci_str = account_id.to_string();
         let ids = sqlx::query!(
             r#"
@@ -47,7 +50,7 @@ impl ContactStore for SqliteContactStore {
         )
         .fetch_all(&self.database)
         .await
-        .map_err(|err| StoreError::Database(format!("{err}")))?
+        .map_err(|err| DatabaseError::Database(format!("{err}")))?
         .into_iter()
         .map(|rec| (rec.device_id as u32).into());
 
@@ -57,7 +60,7 @@ impl ContactStore for SqliteContactStore {
         &mut self,
         account_id: AccountId,
         device_id: DeviceId,
-    ) -> Result<(), StoreError> {
+    ) -> Result<(), ContactStoreError> {
         let aci_str = account_id.to_string();
         let dev_str = device_id.to_string();
         sqlx::query!(
@@ -77,14 +80,14 @@ impl ContactStore for SqliteContactStore {
         .execute(&self.database)
         .await
         .map(|_| ())
-        .map_err(|err| StoreError::Database(format!("{err}")))
+        .map_err(|err| DatabaseError::Database(format!("{err}")).into())
     }
 
     async fn remove_device(
         &mut self,
         account_id: AccountId,
         device_id: DeviceId,
-    ) -> Result<(), StoreError> {
+    ) -> Result<(), ContactStoreError> {
         let aci_str = account_id.to_string();
         let dev_str = device_id.to_string();
         sqlx::query!(
@@ -98,6 +101,6 @@ impl ContactStore for SqliteContactStore {
         .execute(&self.database)
         .await
         .map(|_| ())
-        .map_err(|err| StoreError::Database(format!("{err}")))
+        .map_err(|err| DatabaseError::Database(format!("{err}")).into())
     }
 }

--- a/client/src/storage/sqlite/identity.rs
+++ b/client/src/storage/sqlite/identity.rs
@@ -6,7 +6,7 @@ use libsignal_protocol::{
 };
 use sqlx::{Pool, Sqlite};
 
-use crate::ClientError;
+use crate::{storage::error::StoreError, ClientError};
 
 #[derive(Debug)]
 pub struct SqliteIdentityKeyStore {
@@ -18,7 +18,7 @@ impl SqliteIdentityKeyStore {
         &self,
         address: &ProtocolAddress,
         identity: &IdentityKey,
-    ) -> Result<(), ClientError> {
+    ) -> Result<(), StoreError> {
         let addr = format!("{}", address);
         let key = BASE64_STANDARD.encode(identity.serialize());
 
@@ -35,14 +35,14 @@ impl SqliteIdentityKeyStore {
         .execute(&self.database)
         .await
         .map(|_| ())
-        .map_err(|err| ClientError::Database(format!("{err}")))
+        .map_err(|err| StoreError::Database(format!("{err}")))
     }
 
     async fn insert_account_key_information(
         &self,
         key_pair: IdentityKeyPair,
         registration_id: u32,
-    ) -> Result<(), ClientError> {
+    ) -> Result<(), StoreError> {
         let pk = BASE64_STANDARD.encode(key_pair.identity_key().serialize());
         let sk = BASE64_STANDARD.encode(key_pair.private_key().serialize());
 
@@ -58,7 +58,7 @@ impl SqliteIdentityKeyStore {
         .execute(&self.database)
         .await
         .map(|_| ())
-        .map_err(|err| ClientError::Database(format!("{err}")))
+        .map_err(|err| StoreError::Database(format!("{err}")))
     }
 
     pub async fn new(
@@ -122,7 +122,7 @@ impl IdentityKeyStore for SqliteIdentityKeyStore {
             )),
             Err(err) => Err(SignalProtocolError::ApplicationCallbackError(
                 "Could not fetch Identity Key bundle from database",
-                Box::new(ClientError::Database(format!("{err}"))),
+                Box::new(StoreError::Database(format!("{err}"))),
             )),
         }
     }
@@ -142,7 +142,7 @@ impl IdentityKeyStore for SqliteIdentityKeyStore {
         .map_err(|err| {
             SignalProtocolError::ApplicationCallbackError(
                 "Could not Retrieve local registration id",
-                Box::new(ClientError::Database(format!("{err}"))),
+                Box::new(StoreError::Database(format!("{err}"))),
             )
         })
     }

--- a/client/src/storage/sqlite/identity.rs
+++ b/client/src/storage/sqlite/identity.rs
@@ -6,7 +6,7 @@ use libsignal_protocol::{
 };
 use sqlx::{Pool, Sqlite};
 
-use crate::{storage::error::StoreError, ClientError};
+use crate::storage::error::{DatabaseError, KeyStoreError, StoreCreationError};
 
 #[derive(Debug)]
 pub struct SqliteIdentityKeyStore {
@@ -18,7 +18,7 @@ impl SqliteIdentityKeyStore {
         &self,
         address: &ProtocolAddress,
         identity: &IdentityKey,
-    ) -> Result<(), StoreError> {
+    ) -> Result<(), KeyStoreError> {
         let addr = format!("{}", address);
         let key = BASE64_STANDARD.encode(identity.serialize());
 
@@ -35,14 +35,14 @@ impl SqliteIdentityKeyStore {
         .execute(&self.database)
         .await
         .map(|_| ())
-        .map_err(|err| StoreError::Database(format!("{err}")))
+        .map_err(|err| DatabaseError::Database(format!("{err}")).into())
     }
 
     async fn insert_account_key_information(
         &self,
         key_pair: IdentityKeyPair,
         registration_id: u32,
-    ) -> Result<(), StoreError> {
+    ) -> Result<(), StoreCreationError> {
         let pk = BASE64_STANDARD.encode(key_pair.identity_key().serialize());
         let sk = BASE64_STANDARD.encode(key_pair.private_key().serialize());
 
@@ -58,14 +58,14 @@ impl SqliteIdentityKeyStore {
         .execute(&self.database)
         .await
         .map(|_| ())
-        .map_err(|err| StoreError::Database(format!("{err}")))
+        .map_err(|err| DatabaseError::Database(format!("{err}")).into())
     }
 
     pub async fn new(
         database: Pool<Sqlite>,
         key_pair: IdentityKeyPair,
         registration_id: u32,
-    ) -> Result<Self, ClientError> {
+    ) -> Result<Self, StoreCreationError> {
         let id_store = Self { database };
         id_store
             .insert_account_key_information(key_pair, registration_id)
@@ -73,7 +73,7 @@ impl SqliteIdentityKeyStore {
         Ok(id_store)
     }
 
-    pub async fn load(database: Pool<Sqlite>) -> Result<Self, ClientError> {
+    pub async fn load(database: Pool<Sqlite>) -> Result<Self, StoreCreationError> {
         Ok(Self { database })
     }
 }
@@ -122,7 +122,7 @@ impl IdentityKeyStore for SqliteIdentityKeyStore {
             )),
             Err(err) => Err(SignalProtocolError::ApplicationCallbackError(
                 "Could not fetch Identity Key bundle from database",
-                Box::new(StoreError::Database(format!("{err}"))),
+                Box::new(DatabaseError::Database(format!("{err}"))),
             )),
         }
     }
@@ -142,7 +142,7 @@ impl IdentityKeyStore for SqliteIdentityKeyStore {
         .map_err(|err| {
             SignalProtocolError::ApplicationCallbackError(
                 "Could not Retrieve local registration id",
-                Box::new(StoreError::Database(format!("{err}"))),
+                Box::new(DatabaseError::Database(format!("{err}"))),
             )
         })
     }

--- a/client/src/storage/sqlite/kyber.rs
+++ b/client/src/storage/sqlite/kyber.rs
@@ -6,7 +6,10 @@ use libsignal_protocol::{
 };
 use sqlx::{Pool, Sqlite};
 
-use crate::storage::{error::StoreError, ProvidesKeyId};
+use crate::storage::{
+    error::{DatabaseError, KeyStoreError},
+    ProvidesKeyId,
+};
 
 #[derive(Debug)]
 pub struct SqliteKyberPreKeyStore {
@@ -21,7 +24,7 @@ impl SqliteKyberPreKeyStore {
 
 #[async_trait(?Send)]
 impl ProvidesKeyId<KyberPreKeyId> for SqliteKyberPreKeyStore {
-    async fn next_key_id(&self) -> Result<KyberPreKeyId, StoreError> {
+    async fn next_key_id(&self) -> Result<KyberPreKeyId, KeyStoreError> {
         sqlx::query!(
             r#"
             SELECT
@@ -33,7 +36,7 @@ impl ProvidesKeyId<KyberPreKeyId> for SqliteKyberPreKeyStore {
         .fetch_one(&self.database)
         .await
         .map(|row| KyberPreKeyId::from(row.pkid.unwrap_or(0) as u32 + 1))
-        .map_err(|err| StoreError::Database(format!("{err}")))
+        .map_err(|err| DatabaseError::Database(format!("{err}")).into())
     }
 }
 
@@ -98,7 +101,7 @@ impl KyberPreKeyStore for SqliteKyberPreKeyStore {
         .map_err(|err| {
             SignalProtocolError::ApplicationCallbackError(
                 "save kyber pre key",
-                Box::new(StoreError::Database(format!("{err}"))),
+                Box::new(DatabaseError::Database(format!("{err}"))),
             )
         })
     }

--- a/client/src/storage/sqlite/kyber.rs
+++ b/client/src/storage/sqlite/kyber.rs
@@ -6,7 +6,7 @@ use libsignal_protocol::{
 };
 use sqlx::{Pool, Sqlite};
 
-use crate::{storage::ProvidesKeyId, ClientError};
+use crate::storage::{error::StoreError, ProvidesKeyId};
 
 #[derive(Debug)]
 pub struct SqliteKyberPreKeyStore {
@@ -21,7 +21,7 @@ impl SqliteKyberPreKeyStore {
 
 #[async_trait(?Send)]
 impl ProvidesKeyId<KyberPreKeyId> for SqliteKyberPreKeyStore {
-    async fn next_key_id(&self) -> Result<KyberPreKeyId, ClientError> {
+    async fn next_key_id(&self) -> Result<KyberPreKeyId, StoreError> {
         sqlx::query!(
             r#"
             SELECT
@@ -33,7 +33,7 @@ impl ProvidesKeyId<KyberPreKeyId> for SqliteKyberPreKeyStore {
         .fetch_one(&self.database)
         .await
         .map(|row| KyberPreKeyId::from(row.pkid.unwrap_or(0) as u32 + 1))
-        .map_err(|err| ClientError::Database(format!("{err}")))
+        .map_err(|err| StoreError::Database(format!("{err}")))
     }
 }
 
@@ -98,7 +98,7 @@ impl KyberPreKeyStore for SqliteKyberPreKeyStore {
         .map_err(|err| {
             SignalProtocolError::ApplicationCallbackError(
                 "save kyber pre key",
-                Box::new(ClientError::Database(format!("{err}"))),
+                Box::new(StoreError::Database(format!("{err}"))),
             )
         })
     }

--- a/client/src/storage/sqlite/message.rs
+++ b/client/src/storage/sqlite/message.rs
@@ -4,7 +4,8 @@ use sqlx::{Pool, Sqlite};
 use tokio::sync::broadcast::{self, Receiver, Sender};
 
 use crate::{
-    encryption::envelope::DecryptedEnvelope, storage::traits::message::MessageStore, ClientError,
+    encryption::envelope::DecryptedEnvelope,
+    storage::{error::StoreError, traits::message::MessageStore},
 };
 
 pub struct SqliteMessageStore {
@@ -21,7 +22,7 @@ impl SqliteMessageStore {
 
 #[async_trait(?Send)]
 impl MessageStore for SqliteMessageStore {
-    async fn store_message(&mut self, envelope: DecryptedEnvelope) -> Result<(), ClientError> {
+    async fn store_message(&mut self, envelope: DecryptedEnvelope) -> Result<(), StoreError> {
         let account_id = envelope.source_account_id().to_string();
         let device_id = envelope.source_device_id().to_string();
         let content = envelope.content_bytes();
@@ -40,13 +41,13 @@ impl MessageStore for SqliteMessageStore {
         .execute(&self.database)
         .await
         .map(|_| ())
-        .map_err(|err| ClientError::Database(format!("{err}")));
+        .map_err(|err| StoreError::Database(format!("{err}")));
         match res {
             Ok(()) => self
                 .sender
                 .send(envelope)
                 .inspect_err(|e| debug!("{e}"))
-                .map_err(|_| ClientError::SendError)
+                .map_err(|_| StoreError::SendError)
                 .map(|_| ()),
             Err(e) => Err(e),
         }

--- a/client/src/storage/sqlite/message.rs
+++ b/client/src/storage/sqlite/message.rs
@@ -5,7 +5,10 @@ use tokio::sync::broadcast::{self, Receiver, Sender};
 
 use crate::{
     encryption::envelope::DecryptedEnvelope,
-    storage::{error::StoreError, traits::message::MessageStore},
+    storage::{
+        error::{DatabaseError, MessageStoreError},
+        traits::message::MessageStore,
+    },
 };
 
 pub struct SqliteMessageStore {
@@ -22,7 +25,10 @@ impl SqliteMessageStore {
 
 #[async_trait(?Send)]
 impl MessageStore for SqliteMessageStore {
-    async fn store_message(&mut self, envelope: DecryptedEnvelope) -> Result<(), StoreError> {
+    async fn store_message(
+        &mut self,
+        envelope: DecryptedEnvelope,
+    ) -> Result<(), MessageStoreError> {
         let account_id = envelope.source_account_id().to_string();
         let device_id = envelope.source_device_id().to_string();
         let content = envelope.content_bytes();
@@ -41,15 +47,15 @@ impl MessageStore for SqliteMessageStore {
         .execute(&self.database)
         .await
         .map(|_| ())
-        .map_err(|err| StoreError::Database(format!("{err}")));
+        .map_err(|err| DatabaseError::Database(format!("{err}")));
         match res {
             Ok(()) => self
                 .sender
                 .send(envelope)
                 .inspect_err(|e| debug!("{e}"))
-                .map_err(|_| StoreError::SendError)
+                .map_err(|_| MessageStoreError::SendError)
                 .map(|_| ()),
-            Err(e) => Err(e),
+            Err(e) => Err(e)?,
         }
     }
     fn subscribe(&self) -> Receiver<DecryptedEnvelope> {

--- a/client/src/storage/sqlite/mod.rs
+++ b/client/src/storage/sqlite/mod.rs
@@ -11,8 +11,10 @@ pub use session::SqliteSessionStore;
 pub use signed_pre_key::SqliteSignedPreKeyStore;
 use sqlx::sqlite::SqlitePoolOptions;
 
-use super::{error::StoreError, Store, StoreConfig, StoreType};
-use crate::ClientError;
+use super::{
+    error::{DatabaseError, StoreCreationError},
+    Store, StoreConfig, StoreType,
+};
 
 pub mod account;
 pub mod contact;
@@ -65,12 +67,12 @@ impl SqliteStoreConfig {
     }
 
     /// Load an existing database.
-    pub async fn load(self) -> Result<SqliteStore, ClientError> {
+    pub async fn load(self) -> Result<SqliteStore, StoreCreationError> {
         let database = SqlitePoolOptions::new()
             .connect(&self.connection_string)
             .await
             .map_err(|err| {
-                StoreError::Database(format!(
+                DatabaseError::Database(format!(
                     "Could not connect to the database at '{}': {}",
                     self.connection_string, err
                 ))
@@ -99,12 +101,12 @@ impl StoreConfig for SqliteStoreConfig {
         self,
         key_pair: IdentityKeyPair,
         registration_id: ID,
-    ) -> Result<SqliteStore, ClientError> {
+    ) -> Result<SqliteStore, StoreCreationError> {
         let database = SqlitePoolOptions::new()
             .connect(&self.connection_string)
             .await
             .map_err(|err| {
-                StoreError::Database(format!(
+                DatabaseError::Database(format!(
                     "Could not connect to the database at '{}': {}",
                     self.connection_string, err
                 ))
@@ -113,7 +115,7 @@ impl StoreConfig for SqliteStoreConfig {
             .run(&database)
             .await
             .map_err(|err| {
-                StoreError::Database(format!(
+                DatabaseError::Database(format!(
                     "Could not run migrations on database at '{}': {}",
                     self.connection_string, err
                 ))

--- a/client/src/storage/sqlite/mod.rs
+++ b/client/src/storage/sqlite/mod.rs
@@ -11,7 +11,7 @@ pub use session::SqliteSessionStore;
 pub use signed_pre_key::SqliteSignedPreKeyStore;
 use sqlx::sqlite::SqlitePoolOptions;
 
-use super::{Store, StoreConfig, StoreType};
+use super::{error::StoreError, Store, StoreConfig, StoreType};
 use crate::ClientError;
 
 pub mod account;
@@ -70,7 +70,7 @@ impl SqliteStoreConfig {
             .connect(&self.connection_string)
             .await
             .map_err(|err| {
-                ClientError::Database(format!(
+                StoreError::Database(format!(
                     "Could not connect to the database at '{}': {}",
                     self.connection_string, err
                 ))
@@ -104,7 +104,7 @@ impl StoreConfig for SqliteStoreConfig {
             .connect(&self.connection_string)
             .await
             .map_err(|err| {
-                ClientError::Database(format!(
+                StoreError::Database(format!(
                     "Could not connect to the database at '{}': {}",
                     self.connection_string, err
                 ))
@@ -113,7 +113,7 @@ impl StoreConfig for SqliteStoreConfig {
             .run(&database)
             .await
             .map_err(|err| {
-                ClientError::Database(format!(
+                StoreError::Database(format!(
                     "Could not run migrations on database at '{}': {}",
                     self.connection_string, err
                 ))

--- a/client/src/storage/sqlite/pre_key.rs
+++ b/client/src/storage/sqlite/pre_key.rs
@@ -3,7 +3,7 @@ use base64::{prelude::BASE64_STANDARD, Engine};
 use libsignal_protocol::{PreKeyId, PreKeyRecord, PreKeyStore, SignalProtocolError};
 use sqlx::{Pool, Sqlite};
 
-use crate::{storage::ProvidesKeyId, ClientError};
+use crate::storage::{error::StoreError, ProvidesKeyId};
 
 #[derive(Debug)]
 pub struct SqlitePreKeyStore {
@@ -18,7 +18,7 @@ impl SqlitePreKeyStore {
 
 #[async_trait(?Send)]
 impl ProvidesKeyId<PreKeyId> for SqlitePreKeyStore {
-    async fn next_key_id(&self) -> Result<PreKeyId, ClientError> {
+    async fn next_key_id(&self) -> Result<PreKeyId, StoreError> {
         sqlx::query!(
             r#"
             SELECT
@@ -30,7 +30,7 @@ impl ProvidesKeyId<PreKeyId> for SqlitePreKeyStore {
         .fetch_one(&self.database)
         .await
         .map(|row| PreKeyId::from(row.pkid.unwrap_or(0) as u32 + 1))
-        .map_err(|err| ClientError::Database(format!("{err}")))
+        .map_err(|err| StoreError::Database(format!("{err}")))
     }
 }
 
@@ -73,7 +73,7 @@ impl PreKeyStore for SqlitePreKeyStore {
 
             Err(err) => Err(SignalProtocolError::ApplicationCallbackError(
                 "save pre key",
-                Box::new(ClientError::Database(format!("{err}"))),
+                Box::new(StoreError::Database(format!("{err}"))),
             )),
         }
     }
@@ -102,7 +102,7 @@ impl PreKeyStore for SqlitePreKeyStore {
         .map_err(|err| {
             SignalProtocolError::ApplicationCallbackError(
                 "save pre key",
-                Box::new(ClientError::Database(format!("{err}"))),
+                Box::new(StoreError::Database(format!("{err}"))),
             )
         })
     }
@@ -125,7 +125,7 @@ impl PreKeyStore for SqlitePreKeyStore {
         .map_err(|err| {
             SignalProtocolError::ApplicationCallbackError(
                 "remove pre key",
-                Box::new(ClientError::Database(format!("{err}"))),
+                Box::new(StoreError::Database(format!("{err}"))),
             )
         })
     }

--- a/client/src/storage/sqlite/pre_key.rs
+++ b/client/src/storage/sqlite/pre_key.rs
@@ -3,7 +3,10 @@ use base64::{prelude::BASE64_STANDARD, Engine};
 use libsignal_protocol::{PreKeyId, PreKeyRecord, PreKeyStore, SignalProtocolError};
 use sqlx::{Pool, Sqlite};
 
-use crate::storage::{error::StoreError, ProvidesKeyId};
+use crate::storage::{
+    error::{DatabaseError, KeyStoreError},
+    ProvidesKeyId,
+};
 
 #[derive(Debug)]
 pub struct SqlitePreKeyStore {
@@ -18,7 +21,7 @@ impl SqlitePreKeyStore {
 
 #[async_trait(?Send)]
 impl ProvidesKeyId<PreKeyId> for SqlitePreKeyStore {
-    async fn next_key_id(&self) -> Result<PreKeyId, StoreError> {
+    async fn next_key_id(&self) -> Result<PreKeyId, KeyStoreError> {
         sqlx::query!(
             r#"
             SELECT
@@ -30,7 +33,7 @@ impl ProvidesKeyId<PreKeyId> for SqlitePreKeyStore {
         .fetch_one(&self.database)
         .await
         .map(|row| PreKeyId::from(row.pkid.unwrap_or(0) as u32 + 1))
-        .map_err(|err| StoreError::Database(format!("{err}")))
+        .map_err(|err| DatabaseError::Database(format!("{err}")).into())
     }
 }
 
@@ -73,7 +76,7 @@ impl PreKeyStore for SqlitePreKeyStore {
 
             Err(err) => Err(SignalProtocolError::ApplicationCallbackError(
                 "save pre key",
-                Box::new(StoreError::Database(format!("{err}"))),
+                Box::new(DatabaseError::Database(format!("{err}"))),
             )),
         }
     }
@@ -102,7 +105,7 @@ impl PreKeyStore for SqlitePreKeyStore {
         .map_err(|err| {
             SignalProtocolError::ApplicationCallbackError(
                 "save pre key",
-                Box::new(StoreError::Database(format!("{err}"))),
+                Box::new(DatabaseError::Database(format!("{err}"))),
             )
         })
     }
@@ -125,7 +128,7 @@ impl PreKeyStore for SqlitePreKeyStore {
         .map_err(|err| {
             SignalProtocolError::ApplicationCallbackError(
                 "remove pre key",
-                Box::new(StoreError::Database(format!("{err}"))),
+                Box::new(DatabaseError::Database(format!("{err}"))),
             )
         })
     }

--- a/client/src/storage/sqlite/sender_key.rs
+++ b/client/src/storage/sqlite/sender_key.rs
@@ -4,7 +4,7 @@ use libsignal_protocol::{ProtocolAddress, SenderKeyRecord, SenderKeyStore, Signa
 use sqlx::{Pool, Sqlite};
 use uuid::Uuid;
 
-use crate::ClientError;
+use crate::storage::error::StoreError;
 
 #[derive(Debug)]
 pub struct SqliteSenderKeyStore {
@@ -44,7 +44,7 @@ impl SenderKeyStore for SqliteSenderKeyStore {
         .map_err(|err| {
             SignalProtocolError::ApplicationCallbackError(
                 "store sender key",
-                Box::new(ClientError::Database(format!("{err}"))),
+                Box::new(StoreError::Database(format!("{err}"))),
             )
         })
     }

--- a/client/src/storage/sqlite/sender_key.rs
+++ b/client/src/storage/sqlite/sender_key.rs
@@ -4,7 +4,7 @@ use libsignal_protocol::{ProtocolAddress, SenderKeyRecord, SenderKeyStore, Signa
 use sqlx::{Pool, Sqlite};
 use uuid::Uuid;
 
-use crate::storage::error::StoreError;
+use crate::storage::error::DatabaseError;
 
 #[derive(Debug)]
 pub struct SqliteSenderKeyStore {
@@ -44,7 +44,7 @@ impl SenderKeyStore for SqliteSenderKeyStore {
         .map_err(|err| {
             SignalProtocolError::ApplicationCallbackError(
                 "store sender key",
-                Box::new(StoreError::Database(format!("{err}"))),
+                Box::new(DatabaseError::Database(format!("{err}"))),
             )
         })
     }

--- a/client/src/storage/sqlite/session.rs
+++ b/client/src/storage/sqlite/session.rs
@@ -3,7 +3,7 @@ use base64::{prelude::BASE64_STANDARD, Engine as _};
 use libsignal_protocol::{ProtocolAddress, SessionRecord, SessionStore, SignalProtocolError};
 use sqlx::{Pool, Sqlite};
 
-use crate::ClientError;
+use crate::storage::error::StoreError;
 
 #[derive(Debug)]
 pub struct SqliteSessionStore {
@@ -77,7 +77,7 @@ impl SessionStore for SqliteSessionStore {
         .map_err(|err| {
             SignalProtocolError::ApplicationCallbackError(
                 "store session",
-                Box::new(ClientError::Database(format!("{err}"))),
+                Box::new(StoreError::Database(format!("{err}"))),
             )
         })
     }

--- a/client/src/storage/sqlite/session.rs
+++ b/client/src/storage/sqlite/session.rs
@@ -3,7 +3,7 @@ use base64::{prelude::BASE64_STANDARD, Engine as _};
 use libsignal_protocol::{ProtocolAddress, SessionRecord, SessionStore, SignalProtocolError};
 use sqlx::{Pool, Sqlite};
 
-use crate::storage::error::StoreError;
+use crate::storage::error::DatabaseError;
 
 #[derive(Debug)]
 pub struct SqliteSessionStore {
@@ -77,7 +77,7 @@ impl SessionStore for SqliteSessionStore {
         .map_err(|err| {
             SignalProtocolError::ApplicationCallbackError(
                 "store session",
-                Box::new(StoreError::Database(format!("{err}"))),
+                Box::new(DatabaseError::Database(format!("{err}"))),
             )
         })
     }

--- a/client/src/storage/sqlite/signed_pre_key.rs
+++ b/client/src/storage/sqlite/signed_pre_key.rs
@@ -6,7 +6,7 @@ use libsignal_protocol::{
 };
 use sqlx::{Pool, Sqlite};
 
-use crate::{storage::ProvidesKeyId, ClientError};
+use crate::storage::{error::StoreError, ProvidesKeyId};
 
 #[derive(Debug)]
 pub struct SqliteSignedPreKeyStore {
@@ -21,7 +21,7 @@ impl SqliteSignedPreKeyStore {
 
 #[async_trait(?Send)]
 impl ProvidesKeyId<SignedPreKeyId> for SqliteSignedPreKeyStore {
-    async fn next_key_id(&self) -> Result<SignedPreKeyId, ClientError> {
+    async fn next_key_id(&self) -> Result<SignedPreKeyId, StoreError> {
         sqlx::query!(
             r#"
             SELECT
@@ -33,7 +33,7 @@ impl ProvidesKeyId<SignedPreKeyId> for SqliteSignedPreKeyStore {
         .fetch_one(&self.database)
         .await
         .map(|row| SignedPreKeyId::from(row.pkid.unwrap_or(0) as u32 + 1))
-        .map_err(|err| ClientError::Database(format!("{err}")))
+        .map_err(|err| StoreError::Database(format!("{err}")))
     }
 }
 
@@ -78,7 +78,7 @@ impl SignedPreKeyStore for SqliteSignedPreKeyStore {
             }),
             Err(err) => Err(SignalProtocolError::ApplicationCallbackError(
                 "save signed pre key",
-                Box::new(ClientError::Database(format!("{err}"))),
+                Box::new(StoreError::Database(format!("{err}"))),
             )),
         }
     }
@@ -107,7 +107,7 @@ impl SignedPreKeyStore for SqliteSignedPreKeyStore {
         .map_err(|err| {
             SignalProtocolError::ApplicationCallbackError(
                 "save signed pre key",
-                Box::new(ClientError::Database(format!("{err}"))),
+                Box::new(StoreError::Database(format!("{err}"))),
             )
         })
     }

--- a/client/src/storage/sqlite/signed_pre_key.rs
+++ b/client/src/storage/sqlite/signed_pre_key.rs
@@ -6,7 +6,10 @@ use libsignal_protocol::{
 };
 use sqlx::{Pool, Sqlite};
 
-use crate::storage::{error::StoreError, ProvidesKeyId};
+use crate::storage::{
+    error::{DatabaseError, KeyStoreError},
+    ProvidesKeyId,
+};
 
 #[derive(Debug)]
 pub struct SqliteSignedPreKeyStore {
@@ -21,7 +24,7 @@ impl SqliteSignedPreKeyStore {
 
 #[async_trait(?Send)]
 impl ProvidesKeyId<SignedPreKeyId> for SqliteSignedPreKeyStore {
-    async fn next_key_id(&self) -> Result<SignedPreKeyId, StoreError> {
+    async fn next_key_id(&self) -> Result<SignedPreKeyId, KeyStoreError> {
         sqlx::query!(
             r#"
             SELECT
@@ -33,7 +36,7 @@ impl ProvidesKeyId<SignedPreKeyId> for SqliteSignedPreKeyStore {
         .fetch_one(&self.database)
         .await
         .map(|row| SignedPreKeyId::from(row.pkid.unwrap_or(0) as u32 + 1))
-        .map_err(|err| StoreError::Database(format!("{err}")))
+        .map_err(|err| DatabaseError::Database(format!("{err}")).into())
     }
 }
 
@@ -78,7 +81,7 @@ impl SignedPreKeyStore for SqliteSignedPreKeyStore {
             }),
             Err(err) => Err(SignalProtocolError::ApplicationCallbackError(
                 "save signed pre key",
-                Box::new(StoreError::Database(format!("{err}"))),
+                Box::new(DatabaseError::Database(format!("{err}"))),
             )),
         }
     }
@@ -107,7 +110,7 @@ impl SignedPreKeyStore for SqliteSignedPreKeyStore {
         .map_err(|err| {
             SignalProtocolError::ApplicationCallbackError(
                 "save signed pre key",
-                Box::new(StoreError::Database(format!("{err}"))),
+                Box::new(DatabaseError::Database(format!("{err}"))),
             )
         })
     }

--- a/client/src/storage/traits/account.rs
+++ b/client/src/storage/traits/account.rs
@@ -1,16 +1,17 @@
-use crate::ClientError;
+use crate::storage::error::StoreError;
+
 use async_trait::async_trait;
 use sam_common::address::AccountId;
 use sam_common::DeviceId;
 
 #[async_trait(?Send)]
 pub trait AccountStore {
-    async fn set_account_id(&mut self, account_id: AccountId) -> Result<(), ClientError>;
-    async fn get_account_id(&self) -> Result<AccountId, ClientError>;
-    async fn set_password(&mut self, password: String) -> Result<(), ClientError>;
-    async fn get_password(&self) -> Result<String, ClientError>;
-    async fn set_username(&mut self, username: String) -> Result<(), ClientError>;
-    async fn get_username(&self) -> Result<String, ClientError>;
-    async fn set_device_id(&mut self, device_id: DeviceId) -> Result<(), ClientError>;
-    async fn get_device_id(&self) -> Result<DeviceId, ClientError>;
+    async fn set_account_id(&mut self, account_id: AccountId) -> Result<(), StoreError>;
+    async fn get_account_id(&self) -> Result<AccountId, StoreError>;
+    async fn set_password(&mut self, password: String) -> Result<(), StoreError>;
+    async fn get_password(&self) -> Result<String, StoreError>;
+    async fn set_username(&mut self, username: String) -> Result<(), StoreError>;
+    async fn get_username(&self) -> Result<String, StoreError>;
+    async fn set_device_id(&mut self, device_id: DeviceId) -> Result<(), StoreError>;
+    async fn get_device_id(&self) -> Result<DeviceId, StoreError>;
 }

--- a/client/src/storage/traits/account.rs
+++ b/client/src/storage/traits/account.rs
@@ -1,4 +1,4 @@
-use crate::storage::error::StoreError;
+use crate::storage::error::AccountStoreError;
 
 use async_trait::async_trait;
 use sam_common::address::AccountId;
@@ -6,12 +6,12 @@ use sam_common::DeviceId;
 
 #[async_trait(?Send)]
 pub trait AccountStore {
-    async fn set_account_id(&mut self, account_id: AccountId) -> Result<(), StoreError>;
-    async fn get_account_id(&self) -> Result<AccountId, StoreError>;
-    async fn set_password(&mut self, password: String) -> Result<(), StoreError>;
-    async fn get_password(&self) -> Result<String, StoreError>;
-    async fn set_username(&mut self, username: String) -> Result<(), StoreError>;
-    async fn get_username(&self) -> Result<String, StoreError>;
-    async fn set_device_id(&mut self, device_id: DeviceId) -> Result<(), StoreError>;
-    async fn get_device_id(&self) -> Result<DeviceId, StoreError>;
+    async fn set_account_id(&mut self, account_id: AccountId) -> Result<(), AccountStoreError>;
+    async fn get_account_id(&self) -> Result<AccountId, AccountStoreError>;
+    async fn set_password(&mut self, password: String) -> Result<(), AccountStoreError>;
+    async fn get_password(&self) -> Result<String, AccountStoreError>;
+    async fn set_username(&mut self, username: String) -> Result<(), AccountStoreError>;
+    async fn get_username(&self) -> Result<String, AccountStoreError>;
+    async fn set_device_id(&mut self, device_id: DeviceId) -> Result<(), AccountStoreError>;
+    async fn get_device_id(&self) -> Result<DeviceId, AccountStoreError>;
 }

--- a/client/src/storage/traits/contact.rs
+++ b/client/src/storage/traits/contact.rs
@@ -3,22 +3,24 @@ use std::collections::HashSet;
 use async_trait::async_trait;
 use sam_common::{AccountId, DeviceId};
 
-use crate::storage::error::StoreError;
+use crate::storage::error::ContactStoreError;
 
 #[async_trait(?Send)]
 pub trait ContactStore {
-    async fn get_all_devices(&self, account_id: AccountId)
-        -> Result<HashSet<DeviceId>, StoreError>;
+    async fn get_all_devices(
+        &self,
+        account_id: AccountId,
+    ) -> Result<HashSet<DeviceId>, ContactStoreError>;
     async fn add_device(
         &mut self,
         account_id: AccountId,
         device_id: DeviceId,
-    ) -> Result<(), StoreError>;
+    ) -> Result<(), ContactStoreError>;
     async fn remove_device(
         &mut self,
         account_id: AccountId,
         device_id: DeviceId,
-    ) -> Result<(), StoreError>;
+    ) -> Result<(), ContactStoreError>;
 
-    async fn contains_contact(&self, account_id: AccountId) -> Result<bool, StoreError>;
+    async fn contains_contact(&self, account_id: AccountId) -> Result<bool, ContactStoreError>;
 }

--- a/client/src/storage/traits/contact.rs
+++ b/client/src/storage/traits/contact.rs
@@ -3,24 +3,22 @@ use std::collections::HashSet;
 use async_trait::async_trait;
 use sam_common::{AccountId, DeviceId};
 
-use crate::ClientError;
+use crate::storage::error::StoreError;
 
 #[async_trait(?Send)]
 pub trait ContactStore {
-    async fn get_all_devices(
-        &self,
-        account_id: AccountId,
-    ) -> Result<HashSet<DeviceId>, ClientError>;
+    async fn get_all_devices(&self, account_id: AccountId)
+        -> Result<HashSet<DeviceId>, StoreError>;
     async fn add_device(
         &mut self,
         account_id: AccountId,
         device_id: DeviceId,
-    ) -> Result<(), ClientError>;
+    ) -> Result<(), StoreError>;
     async fn remove_device(
         &mut self,
         account_id: AccountId,
         device_id: DeviceId,
-    ) -> Result<(), ClientError>;
+    ) -> Result<(), StoreError>;
 
-    async fn contains_contact(&self, account_id: AccountId) -> Result<bool, ClientError>;
+    async fn contains_contact(&self, account_id: AccountId) -> Result<bool, StoreError>;
 }

--- a/client/src/storage/traits/message.rs
+++ b/client/src/storage/traits/message.rs
@@ -1,10 +1,10 @@
 use async_trait::async_trait;
 use tokio::sync::broadcast::Receiver;
 
-use crate::{encryption::envelope::DecryptedEnvelope, ClientError};
+use crate::{encryption::envelope::DecryptedEnvelope, storage::error::StoreError};
 
 #[async_trait(?Send)]
 pub trait MessageStore {
-    async fn store_message(&mut self, envelope: DecryptedEnvelope) -> Result<(), ClientError>;
+    async fn store_message(&mut self, envelope: DecryptedEnvelope) -> Result<(), StoreError>;
     fn subscribe(&self) -> Receiver<DecryptedEnvelope>;
 }

--- a/client/src/storage/traits/message.rs
+++ b/client/src/storage/traits/message.rs
@@ -1,10 +1,11 @@
 use async_trait::async_trait;
 use tokio::sync::broadcast::Receiver;
 
-use crate::{encryption::envelope::DecryptedEnvelope, storage::error::StoreError};
+use crate::{encryption::envelope::DecryptedEnvelope, storage::error::MessageStoreError};
 
 #[async_trait(?Send)]
 pub trait MessageStore {
-    async fn store_message(&mut self, envelope: DecryptedEnvelope) -> Result<(), StoreError>;
+    async fn store_message(&mut self, envelope: DecryptedEnvelope)
+        -> Result<(), MessageStoreError>;
     fn subscribe(&self) -> Receiver<DecryptedEnvelope>;
 }

--- a/client/tests/conformance/account.rs
+++ b/client/tests/conformance/account.rs
@@ -1,7 +1,7 @@
 use super::{in_mem, sqlite};
 use rstest::rstest;
+use sam_client::storage::error::StoreError;
 use sam_client::storage::AccountStore;
-use sam_client::ClientError;
 use sam_common::address::AccountId;
 use sam_common::DeviceId;
 
@@ -13,7 +13,7 @@ async fn account_id_can_be_stored_and_retrieved(#[case] mut account_store: impl 
     let account_id = AccountId::generate();
     assert!(matches!(
         account_store.get_account_id().await.unwrap_err(),
-        ClientError::NoAccountId
+        StoreError::NoAccountId
     ));
     assert!(account_store
         .set_account_id(account_id.to_owned())
@@ -30,7 +30,7 @@ async fn password_can_be_stored_and_retrieved(#[case] mut account_store: impl Ac
     let password = "MyPassword".to_owned();
     assert!(matches!(
         account_store.get_password().await.unwrap_err(),
-        ClientError::NoPassword
+        StoreError::NoPassword
     ));
     assert!(account_store
         .set_password(password.to_owned())
@@ -47,7 +47,7 @@ async fn username_can_be_stored_and_retrieved(#[case] mut account_store: impl Ac
     let username = "MyUsername".to_owned();
     assert!(matches!(
         account_store.get_username().await.unwrap_err(),
-        ClientError::NoUsername
+        StoreError::NoUsername
     ));
     assert!(account_store
         .set_username(username.to_owned())
@@ -67,7 +67,7 @@ async fn device_id_can_be_stored_and_retrieved(
     let device_id: DeviceId = device_id.into();
     assert!(matches!(
         account_store.get_device_id().await.unwrap_err(),
-        ClientError::NoDeviceId
+        StoreError::NoDeviceId
     ));
     assert!(account_store
         .set_device_id(device_id.to_owned())

--- a/client/tests/conformance/account.rs
+++ b/client/tests/conformance/account.rs
@@ -1,6 +1,6 @@
 use super::{in_mem, sqlite};
 use rstest::rstest;
-use sam_client::storage::error::StoreError;
+use sam_client::storage::error::AccountStoreError;
 use sam_client::storage::AccountStore;
 use sam_common::address::AccountId;
 use sam_common::DeviceId;
@@ -13,7 +13,7 @@ async fn account_id_can_be_stored_and_retrieved(#[case] mut account_store: impl 
     let account_id = AccountId::generate();
     assert!(matches!(
         account_store.get_account_id().await.unwrap_err(),
-        StoreError::NoAccountId
+        AccountStoreError::NoAccountId
     ));
     assert!(account_store
         .set_account_id(account_id.to_owned())
@@ -30,7 +30,7 @@ async fn password_can_be_stored_and_retrieved(#[case] mut account_store: impl Ac
     let password = "MyPassword".to_owned();
     assert!(matches!(
         account_store.get_password().await.unwrap_err(),
-        StoreError::NoPassword
+        AccountStoreError::NoPassword
     ));
     assert!(account_store
         .set_password(password.to_owned())
@@ -47,7 +47,7 @@ async fn username_can_be_stored_and_retrieved(#[case] mut account_store: impl Ac
     let username = "MyUsername".to_owned();
     assert!(matches!(
         account_store.get_username().await.unwrap_err(),
-        StoreError::NoUsername
+        AccountStoreError::NoUsername
     ));
     assert!(account_store
         .set_username(username.to_owned())
@@ -67,7 +67,7 @@ async fn device_id_can_be_stored_and_retrieved(
     let device_id: DeviceId = device_id.into();
     assert!(matches!(
         account_store.get_device_id().await.unwrap_err(),
-        StoreError::NoDeviceId
+        AccountStoreError::NoDeviceId
     ));
     assert!(account_store
         .set_device_id(device_id.to_owned())

--- a/e2e/tests/message.rs
+++ b/e2e/tests/message.rs
@@ -7,6 +7,7 @@ use rstest::rstest;
 use sam_client::{
     client::SqliteClientType,
     encryption::envelope::DecryptedEnvelope,
+    logic::LogicError,
     net::{
         http_client::HttpClientConfig,
         protocol::WebSocketProtocolClientConfig,
@@ -217,7 +218,7 @@ async fn test_alice_send_to_bob_missing_devices() {
 
         assert!(matches!(
             alice.send_message(bob_id, "Hello again, Bob").await,
-            Err(ClientError::MissingDevices)
+            Err(ClientError::Logic(LogicError::MissingDevices))
         ));
 
         assert!(alice.send_message(bob_id, "Hello again, Bob").await.is_ok());
@@ -330,7 +331,10 @@ async fn test_alice_send_to_bob_and_self() {
 
         let bob_expected = "Hello bob!";
         let res = alice.send_message(bob_id, bob_expected).await;
-        assert!(matches!(res, Err(ClientError::MissingDevices)));
+        assert!(matches!(
+            res,
+            Err(ClientError::Logic(LogicError::MissingDevices))
+        ));
 
         alice
             .send_message(bob_id, bob_expected)


### PR DESCRIPTION
Added `StoreCreationError` `LogicError` and `EncryptionError`, now `denim-on-sam` will not receive a `ClientError` when using sam. When this pr gets in, it should also be changed on denim-on-sam as it no longer receives the `ClientError`

There are also Errors for `KeyStore`, `AccountStore`, `ContactStore`, `MessageStore` and `DatabaseStore`

closes #84 